### PR TITLE
Add UamiOAuthProvider for Azure UAMI token fetching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-# Claude Code Project Instructions
-
-## Git
-
-- Use `git push-external` instead of `git push` when pushing to remote.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Project Instructions
+
+## Git
+
+- Use `git push-external` instead of `git push` when pushing to remote.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,8 @@ target_link_libraries(schemaregistry
         OpenSSL::Crypto
         cpr::cpr
         absl::strings # for base64_decode in JsonValue
+        absl::hash
+        absl::raw_hash_set # for flat_hash_map used in SchemaStore, TtlLruCache, etc.
 )
 
 # Conditionally link Avro

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -115,6 +115,12 @@ endif()
 
 # Protobuf compilation and dependencies are handled in add_example_executable function
 
+# UAMI OAuth example (no rdkafka/protobuf/serde dependencies)
+add_executable(uami_oauth_example UamiOAuthExample.cpp)
+target_link_libraries(uami_oauth_example schemaregistry)
+add_dependencies(example uami_oauth_example)
+list(APPEND EXAMPLE_TARGETS uami_oauth_example)
+
 # Set output directory for examples (only if examples were built)
 if(EXAMPLE_TARGETS)
     set_target_properties(${EXAMPLE_TARGETS}

--- a/example/OAuthSchemaRegistry.cpp
+++ b/example/OAuthSchemaRegistry.cpp
@@ -76,5 +76,24 @@ int main() {
     std::cout << "Factory (config map): Found " << subjects.size() << " subjects" << std::endl;
   }
 
+  // Example 6: Azure User-Assigned Managed Identity (UAMI)
+  // See UamiOAuthExample.cpp for a runnable version with CLI args.
+  {
+    UamiOAuthProvider::Config uami_config;
+    uami_config.uami_endpoint_query = "?api-version=2018-02-01&resource=https://confluent.cloud&client_id=<managed-identity-client-id>";
+    uami_config.logical_cluster = "lsrc-12345";
+    uami_config.identity_pool_id = "pool-abcd";
+
+    auto provider = std::make_shared<UamiOAuthProvider>(uami_config);
+
+    auto config = std::make_shared<ClientConfiguration>(
+        std::vector<std::string>{"https://psrc-123456.us-east-1.aws.confluent.cloud"});
+    config->setOAuthProvider(provider);
+
+    auto client = SchemaRegistryClient::newClient(config);
+    auto subjects = client->getAllSubjects();
+    std::cout << "UAMI: Found " << subjects.size() << " subjects" << std::endl;
+  }
+
   return 0;
 }

--- a/example/OAuthSchemaRegistry.cpp
+++ b/example/OAuthSchemaRegistry.cpp
@@ -9,7 +9,9 @@
 #include <string>
 
 #include "schemaregistry/rest/ClientConfiguration.h"
-#include "schemaregistry/rest/OAuthProvider.h"
+#include "schemaregistry/rest/CustomOAuthProvider.h"
+#include "schemaregistry/rest/OAuthClientProvider.h"
+#include "schemaregistry/rest/UamiOAuthProvider.h"
 #include "schemaregistry/rest/SchemaRegistryClient.h"
 
 using namespace schemaregistry::rest;

--- a/example/UamiOAuthExample.cpp
+++ b/example/UamiOAuthExample.cpp
@@ -1,0 +1,82 @@
+/**
+ * Azure UAMI OAuth Example for Schema Registry
+ *
+ * Run on an Azure VM with a User-Assigned Managed Identity:
+ *   ./uami_oauth_example \
+ *       --schema.registry.url=https://psrc-xxxxx.region.provider.confluent.cloud \
+ *       --uami.client.id=<managed-identity-client-id> \
+ *       --uami.resource=api://<resource-id> \
+ *       --bearer.auth.logical.cluster=lsrc-xxxxx \
+ *       --bearer.auth.identity.pool.id=pool-xxxxx
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "schemaregistry/rest/ClientConfiguration.h"
+#include "schemaregistry/rest/OAuthProvider.h"
+#include "schemaregistry/rest/SchemaRegistryClient.h"
+
+using namespace schemaregistry::rest;
+
+static std::string get_arg(int argc, char* argv[], const std::string& key) {
+  std::string prefix = "--" + key + "=";
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg.rfind(prefix, 0) == 0) {
+      return arg.substr(prefix.size());
+    }
+  }
+  return "";
+}
+
+int main(int argc, char* argv[]) {
+  std::string sr_url = get_arg(argc, argv, "schema.registry.url");
+  std::string uami_client_id = get_arg(argc, argv, "uami.client.id");
+  std::string uami_resource = get_arg(argc, argv, "uami.resource");
+  std::string logical_cluster = get_arg(argc, argv, "bearer.auth.logical.cluster");
+  std::string identity_pool_id = get_arg(argc, argv, "bearer.auth.identity.pool.id");
+
+  if (sr_url.empty() || uami_client_id.empty() || uami_resource.empty() ||
+      logical_cluster.empty() || identity_pool_id.empty()) {
+    std::cerr << "Usage: " << argv[0] << " \\\n"
+              << "    --schema.registry.url=<url> \\\n"
+              << "    --uami.client.id=<managed-identity-client-id> \\\n"
+              << "    --uami.resource=<resource-uri> \\\n"
+              << "    --bearer.auth.logical.cluster=<lsrc-id> \\\n"
+              << "    --bearer.auth.identity.pool.id=<pool-id>\n";
+    return 1;
+  }
+
+  std::string query_url = "?api-version=2018-02-01"
+                          "&resource=" + uami_resource +
+                          "&client_id=" + uami_client_id;
+
+  UamiOAuthProvider::Config uami_config;
+  uami_config.uami_endpoint_query = query_url;
+  uami_config.logical_cluster = logical_cluster;
+  uami_config.identity_pool_id = identity_pool_id;
+
+  auto provider = std::make_shared<UamiOAuthProvider>(uami_config);
+
+  std::cout << "Fetching UAMI token from Azure IMDS..." << std::endl;
+  auto fields = provider->get_bearer_fields();
+  std::cout << "Token obtained successfully (length=" << fields.access_token.size() << ")" << std::endl;
+
+  auto config = std::make_shared<ClientConfiguration>(
+      std::vector<std::string>{sr_url});
+  config->setOAuthProvider(provider);
+
+  auto client = SchemaRegistryClient::newClient(config);
+
+  std::cout << "Calling getAllSubjects()..." << std::endl;
+  auto subjects = client->getAllSubjects();
+  std::cout << "Found " << subjects.size() << " subjects:" << std::endl;
+  for (const auto& s : subjects) {
+    std::cout << "  - " << s << std::endl;
+  }
+
+  return 0;
+}

--- a/example/UamiOAuthExample.cpp
+++ b/example/UamiOAuthExample.cpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include "schemaregistry/rest/ClientConfiguration.h"
-#include "schemaregistry/rest/OAuthProvider.h"
+#include "schemaregistry/rest/UamiOAuthProvider.h"
 #include "schemaregistry/rest/SchemaRegistryClient.h"
 
 using namespace schemaregistry::rest;

--- a/include/schemaregistry/rest/CustomOAuthProvider.h
+++ b/include/schemaregistry/rest/CustomOAuthProvider.h
@@ -1,0 +1,67 @@
+/**
+ * Custom OAuth Provider with user-provided token function
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "schemaregistry/rest/OAuthProvider.h"
+
+namespace schemaregistry::rest {
+
+/**
+ * Custom OAuth provider that delegates token fetching to a user-provided function.
+ *
+ * This allows users to implement custom token fetching logic without implementing
+ * a full provider class.
+ *
+ * Example usage:
+ * @code
+ * auto provider = std::make_shared<CustomOAuthProvider>(
+ *     []() { return fetch_token_from_my_idp(); },
+ *     "lsrc-12345",
+ *     "pool-67890"
+ * );
+ * @endcode
+ *
+ * Note: The function is called on every get_bearer_fields() call.
+ * Users should implement their own caching and thread safety if needed.
+ */
+class CustomOAuthProvider : public OAuthProvider {
+ public:
+  /**
+   * Function type that returns an access token string.
+   * The function should handle all token fetching logic including:
+   * - Fetching from custom OAuth endpoints
+   * - Caching (if desired)
+   * - Thread safety (if needed)
+   * - Error handling
+   *
+   * @return Access token string
+   * @throws std::runtime_error if unable to fetch token
+   */
+  using TokenFetchFunction = std::function<std::string()>;
+
+  /**
+   * Construct custom OAuth provider with user-provided token fetch function.
+   *
+   * @param fetch_fn Function that returns access token (required)
+   * @param logical_cluster Schema Registry logical cluster ID (optional, required for Confluent Cloud)
+   * @param identity_pool_id Identity pool ID(s) as comma-separated string (optional)
+   * @throws std::invalid_argument if fetch_fn is empty
+   */
+  CustomOAuthProvider(TokenFetchFunction fetch_fn,
+                     std::string logical_cluster = "",
+                     std::string identity_pool_id = "");
+
+  BearerFields get_bearer_fields() override;
+
+ private:
+  const TokenFetchFunction fetch_fn_;
+  const std::string logical_cluster_;
+  const std::string identity_pool_id_;
+};
+
+}  // namespace schemaregistry::rest

--- a/include/schemaregistry/rest/OAuthClientProvider.h
+++ b/include/schemaregistry/rest/OAuthClientProvider.h
@@ -1,0 +1,52 @@
+/**
+ * OAuth 2.0 Client Credentials Provider
+ */
+
+#pragma once
+
+#include "schemaregistry/rest/OAuthProvider.h"
+
+namespace schemaregistry::rest {
+
+/**
+ * OAuth 2.0 Client Credentials provider.
+ *
+ * Implements automatic token fetching using OAuth 2.0 Client Credentials
+ * grant flow.
+ */
+class OAuthClientProvider : public CachingOAuthProvider {
+ public:
+  /**
+   * Configuration for OAuth Client Credentials flow.
+   */
+  struct Config : CacheConfig {
+    // Required OAuth parameters
+    std::string client_id;
+    std::string client_secret;
+    std::string scope;
+    std::string token_endpoint_url;
+
+    /**
+     * Validate configuration has all required fields.
+     *
+     * @throws std::invalid_argument if configuration is invalid
+     */
+    void validate() const;
+  };
+
+  /**
+   * Construct OAuth provider with configuration.
+   *
+   * @param config OAuth configuration (validated on construction)
+   * @throws std::invalid_argument if configuration is invalid
+   */
+  explicit OAuthClientProvider(const Config& config);
+
+ protected:
+  OAuthToken fetch_token() override;
+
+ private:
+  const Config config_;
+};
+
+}  // namespace schemaregistry::rest

--- a/include/schemaregistry/rest/OAuthProvider.h
+++ b/include/schemaregistry/rest/OAuthProvider.h
@@ -228,4 +228,49 @@ class CustomOAuthProvider : public OAuthProvider {
   const std::string identity_pool_id_;
 };
 
+/**
+ * Azure User-Assigned Managed Identity (UAMI) OAuth provider.
+ *
+ * Fetches tokens from the Azure Instance Metadata Service (IMDS) using
+ * a managed identity's client ID. Includes automatic token caching and
+ * refresh with the same double-checked locking pattern as OAuthClientProvider.
+ */
+class UamiOAuthProvider : public OAuthProvider {
+ public:
+  struct Config {
+    // Azure IMDS base URL (default: standard Azure IMDS endpoint)
+    std::string uami_url = "http://169.254.169.254/metadata/identity/oauth2/token";
+
+    // Required: query string appended to uami_url (contains resource, client_id, api-version, etc.)
+    std::string uami_endpoint_query;
+
+    // Confluent Cloud parameters
+    std::string logical_cluster;
+    std::string identity_pool_id;
+
+    // Retry configuration
+    int max_retries{3};
+    int retry_base_delay_ms{1000};
+    int retry_max_delay_ms{20000};
+    double token_refresh_threshold{0.8};
+    int http_timeout_seconds{30};
+
+    void validate() const;
+    void set_identity_pool_ids(const std::vector<std::string>& pool_ids);
+  };
+
+  explicit UamiOAuthProvider(const Config& config);
+
+  BearerFields get_bearer_fields() override;
+
+  void invalidate_token();
+
+ private:
+  OAuthToken fetch_token();
+
+  const Config config_;
+  mutable std::shared_mutex mutex_;
+  OAuthToken token_;
+};
+
 }  // namespace schemaregistry::rest

--- a/include/schemaregistry/rest/OAuthProvider.h
+++ b/include/schemaregistry/rest/OAuthProvider.h
@@ -1,8 +1,10 @@
 /**
  * OAuth 2.0 Provider for Schema Registry Client
  *
- * Implements OAuth 2.0 Client Credentials grant (RFC 6749 Section 4.4)
- * with automatic token caching and refresh.
+ * Base classes for OAuth bearer authentication. For concrete providers see:
+ * - OAuthClientProvider.h (Client Credentials grant)
+ * - CustomOAuthProvider.h (user-provided token function)
+ * - UamiOAuthProvider.h (Azure UAMI via IMDS)
  *
  * Authentication Methods (Mutually Exclusive):
  * ClientConfiguration supports three authentication methods:
@@ -18,8 +20,6 @@
 
 #include <chrono>
 #include <functional>
-#include <map>
-#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
@@ -100,56 +100,26 @@ struct OAuthToken {
 };
 
 /**
- * OAuth 2.0 Client Credentials provider.
+ * Base class for OAuth providers with automatic token caching and refresh.
  *
- * Implements automatic token fetching using OAuth 2.0 Client Credentials
- * grant flow.
+ * Provides thread-safe token caching using double-checked locking with
+ * shared_mutex. Subclasses implement fetch_token() for the actual token
+ * retrieval (HTTP call + parsing + retry).
  */
-class OAuthClientProvider : public OAuthProvider {
+class CachingOAuthProvider : public OAuthProvider {
  public:
-  /**
-   * Configuration for OAuth Client Credentials flow.
-   */
-  struct Config {
-    // Required OAuth parameters
-    std::string client_id;
-    std::string client_secret;
-    std::string scope;
-    std::string token_endpoint_url;
+  struct CacheConfig {
+    std::string logical_cluster;
+    std::string identity_pool_id;
 
-    // Optional Confluent Cloud parameters
-    // Required for Confluent Cloud
-    std::string logical_cluster;      // Schema Registry logical cluster ID (e.g., "lsrc-12345")
-    std::string identity_pool_id;     // Identity pool ID (e.g., "pool-abcd")
-
-    // Optional retry configuration
     int max_retries{3};
     int retry_base_delay_ms{1000};
     int retry_max_delay_ms{20000};
-
-    // Optional token refresh behavior
-    // Token is refreshed when elapsed time > threshold * total_lifetime
-    // Default: 0.8 (refreshes when 80% of token lifetime has elapsed)
     double token_refresh_threshold{0.8};
-
-    // Optional HTTP timeout
     int http_timeout_seconds{30};
 
-    /**
-     * Validate configuration has all required fields.
-     *
-     * @throws std::invalid_argument if configuration is invalid
-     */
     void validate() const;
   };
-
-  /**
-   * Construct OAuth provider with configuration.
-   *
-   * @param config OAuth configuration (validated on construction)
-   * @throws std::invalid_argument if configuration is invalid
-   */
-  explicit OAuthClientProvider(const Config& config);
 
   BearerFields get_bearer_fields() override;
 
@@ -158,117 +128,55 @@ class OAuthClientProvider : public OAuthProvider {
    */
   void invalidate_token();
 
- private:
+ protected:
+  explicit CachingOAuthProvider(const CacheConfig& cache_config);
+
   /**
-   * Fetch new token from OAuth provider using Client Credentials grant.
+   * Fetch a new token from the token endpoint.
    *
-   * Performs exponential backoff with jitter on failures.
+   * Subclasses implement the HTTP request and response parsing.
    *
-   * @return Newly fetched OAuth token
+   * @return Newly fetched OAuthToken
    * @throws std::runtime_error if unable to fetch token after retries
    */
-  OAuthToken fetch_token();
-
-  const Config config_;
-
-  mutable std::shared_mutex mutex_;  // Shared mutex for thread-safe token access
-  OAuthToken token_;
-};
-
-/**
- * Custom OAuth provider that delegates token fetching to a user-provided function.
- *
- * This allows users to implement custom token fetching logic without implementing
- * a full provider class.
- *
- * Example usage:
- * @code
- * auto provider = std::make_shared<CustomOAuthProvider>(
- *     []() { return fetch_token_from_my_idp(); },
- *     "lsrc-12345",
- *     "pool-67890"
- * );
- * @endcode
- *
- * Note: The function is called on every get_bearer_fields() call.
- * Users should implement their own caching and thread safety if needed.
- */
-class CustomOAuthProvider : public OAuthProvider {
- public:
-  /**
-   * Function type that returns an access token string.
-   * The function should handle all token fetching logic including:
-   * - Fetching from custom OAuth endpoints
-   * - Caching (if desired)
-   * - Thread safety (if needed)
-   * - Error handling
-   *
-   * @return Access token string
-   * @throws std::runtime_error if unable to fetch token
-   */
-  using TokenFetchFunction = std::function<std::string()>;
+  virtual OAuthToken fetch_token() = 0;
 
   /**
-   * Construct custom OAuth provider with user-provided token fetch function.
-   *
-   * @param fetch_fn Function that returns access token (required)
-   * @param logical_cluster Schema Registry logical cluster ID (optional, required for Confluent Cloud)
-   * @param identity_pool_id Identity pool ID (optional, required for Confluent Cloud)
-   * @throws std::invalid_argument if fetch_fn is empty
+   * Token response from an HTTP request, used by fetch_with_retry.
    */
-  CustomOAuthProvider(TokenFetchFunction fetch_fn,
-                     std::string logical_cluster = "",
-                     std::string identity_pool_id = "");
-
-  BearerFields get_bearer_fields() override;
-
- private:
-  const TokenFetchFunction fetch_fn_;
-  const std::string logical_cluster_;
-  const std::string identity_pool_id_;
-};
-
-/**
- * Azure User-Assigned Managed Identity (UAMI) OAuth provider.
- *
- * Fetches tokens from the Azure Instance Metadata Service (IMDS) using
- * a managed identity's client ID. Includes automatic token caching and
- * refresh with the same double-checked locking pattern as OAuthClientProvider.
- */
-class UamiOAuthProvider : public OAuthProvider {
- public:
-  struct Config {
-    // Azure IMDS base URL (default: standard Azure IMDS endpoint)
-    std::string uami_url = "http://169.254.169.254/metadata/identity/oauth2/token";
-
-    // Required: query string appended to uami_url (contains resource, client_id, api-version, etc.)
-    std::string uami_endpoint_query;
-
-    // Confluent Cloud parameters
-    std::string logical_cluster;
-    std::string identity_pool_id;
-
-    // Retry configuration
-    int max_retries{3};
-    int retry_base_delay_ms{1000};
-    int retry_max_delay_ms{20000};
-    double token_refresh_threshold{0.8};
-    int http_timeout_seconds{30};
-
-    void validate() const;
-    void set_identity_pool_ids(const std::vector<std::string>& pool_ids);
+  struct TokenResponse {
+    int status_code{0};
+    std::string text;
   };
 
-  explicit UamiOAuthProvider(const Config& config);
+  /**
+   * Execute an HTTP request with retry and exponential backoff.
+   *
+   * Retries on network errors and retriable HTTP status codes.
+   * Returns the successful response body for the caller to parse.
+   *
+   * @param provider_name Name for error messages (e.g., "OAuth", "UAMI")
+   * @param make_request Function that performs the HTTP request
+   * @return Response body text on success (2xx)
+   * @throws std::runtime_error if unable to get a successful response after retries
+   */
+  std::string fetch_with_retry(
+      const std::string& provider_name,
+      const std::function<TokenResponse()>& make_request);
 
-  BearerFields get_bearer_fields() override;
+  /**
+   * Parse a standard OAuth token response (access_token string, expires_in int).
+   *
+   * @param json_text Raw JSON response body
+   * @param provider_name Name for error messages
+   * @return Parsed OAuthToken
+   */
+  static OAuthToken parse_standard_token_response(
+      const std::string& json_text, const std::string& provider_name);
 
-  void invalidate_token();
+  const CacheConfig cache_config_;
 
  private:
-  OAuthToken fetch_token();
-
-  const Config config_;
   mutable std::shared_mutex mutex_;
   OAuthToken token_;
 };

--- a/include/schemaregistry/rest/UamiOAuthProvider.h
+++ b/include/schemaregistry/rest/UamiOAuthProvider.h
@@ -1,0 +1,40 @@
+/**
+ * Azure User-Assigned Managed Identity (UAMI) OAuth Provider
+ */
+
+#pragma once
+
+#include <string>
+
+#include "schemaregistry/rest/OAuthProvider.h"
+
+namespace schemaregistry::rest {
+
+/**
+ * Azure User-Assigned Managed Identity (UAMI) OAuth provider.
+ *
+ * Fetches tokens from the Azure Instance Metadata Service (IMDS) using
+ * a managed identity's client ID.
+ */
+class UamiOAuthProvider : public CachingOAuthProvider {
+ public:
+  struct Config : CacheConfig {
+    // Azure IMDS base URL (default: standard Azure IMDS endpoint)
+    std::string uami_url = "http://169.254.169.254/metadata/identity/oauth2/token";
+
+    // Required: query string appended to uami_url (contains resource, client_id, api-version, etc.)
+    std::string uami_endpoint_query;
+
+    void validate() const;
+  };
+
+  explicit UamiOAuthProvider(const Config& config);
+
+ protected:
+  OAuthToken fetch_token() override;
+
+ private:
+  const Config config_;
+};
+
+}  // namespace schemaregistry::rest

--- a/src/rest/CustomOAuthProvider.cpp
+++ b/src/rest/CustomOAuthProvider.cpp
@@ -1,0 +1,32 @@
+/**
+ * Custom OAuth Provider Implementation
+ */
+
+#include "schemaregistry/rest/CustomOAuthProvider.h"
+
+#include <stdexcept>
+
+namespace schemaregistry::rest {
+
+CustomOAuthProvider::CustomOAuthProvider(TokenFetchFunction fetch_fn,
+                                         std::string logical_cluster,
+                                         std::string identity_pool_id)
+    : fetch_fn_(std::move(fetch_fn)),
+      logical_cluster_(std::move(logical_cluster)),
+      identity_pool_id_(std::move(identity_pool_id)) {
+  if (!fetch_fn_) {
+    throw std::invalid_argument("fetch_fn cannot be empty");
+  }
+}
+
+BearerFields CustomOAuthProvider::get_bearer_fields() {
+  std::string access_token = fetch_fn_();
+
+  if (access_token.empty()) {
+    throw std::runtime_error("Custom token fetch function returned empty token");
+  }
+
+  return BearerFields{std::move(access_token), logical_cluster_, identity_pool_id_};
+}
+
+}  // namespace schemaregistry::rest

--- a/src/rest/OAuthClientProvider.cpp
+++ b/src/rest/OAuthClientProvider.cpp
@@ -1,0 +1,62 @@
+/**
+ * OAuth 2.0 Client Credentials Provider Implementation
+ */
+
+#include "schemaregistry/rest/OAuthClientProvider.h"
+
+#include <cpr/cpr.h>
+
+#include <chrono>
+#include <stdexcept>
+
+namespace schemaregistry::rest {
+
+// ============================================================================
+// OAuthClientProvider::Config Implementation
+// ============================================================================
+
+void OAuthClientProvider::Config::validate() const {
+  if (client_id.empty()) {
+    throw std::invalid_argument("client_id is required");
+  }
+  if (client_secret.empty()) {
+    throw std::invalid_argument("client_secret is required");
+  }
+  if (scope.empty()) {
+    throw std::invalid_argument("scope is required");
+  }
+  if (token_endpoint_url.empty()) {
+    throw std::invalid_argument("token_endpoint_url is required");
+  }
+  CacheConfig::validate();
+}
+
+// ============================================================================
+// OAuthClientProvider Implementation
+// ============================================================================
+
+OAuthClientProvider::OAuthClientProvider(const Config& config)
+    : CachingOAuthProvider(config), config_(config) {
+  config_.validate();
+}
+
+OAuthToken OAuthClientProvider::fetch_token() {
+  cpr::Payload payload{{"grant_type", "client_credentials"},
+                       {"client_id", config_.client_id},
+                       {"client_secret", config_.client_secret},
+                       {"scope", config_.scope}};
+
+  std::string response_text = fetch_with_retry(
+      "OAuth",
+      [&]() -> TokenResponse {
+        auto r = cpr::Post(
+            cpr::Url{config_.token_endpoint_url}, payload,
+            cpr::Header{{"Content-Type", "application/x-www-form-urlencoded"}},
+            cpr::Timeout{std::chrono::seconds(cache_config_.http_timeout_seconds)});
+        return {static_cast<int>(r.status_code), r.text};
+      });
+
+  return parse_standard_token_response(response_text, "OAuth");
+}
+
+}  // namespace schemaregistry::rest

--- a/src/rest/OAuthProvider.cpp
+++ b/src/rest/OAuthProvider.cpp
@@ -190,4 +190,159 @@ BearerFields CustomOAuthProvider::get_bearer_fields() {
   return BearerFields{std::move(access_token), logical_cluster_, identity_pool_id_};
 }
 
+// ============================================================================
+// UamiOAuthProvider::Config Implementation
+// ============================================================================
+
+void UamiOAuthProvider::Config::validate() const {
+  if (uami_endpoint_query.empty()) {
+    throw std::invalid_argument("uami_endpoint_query is required");
+  }
+  if (max_retries < 0) {
+    throw std::invalid_argument("max_retries must be non-negative");
+  }
+  if (retry_base_delay_ms <= 0) {
+    throw std::invalid_argument("retry_base_delay_ms must be positive");
+  }
+  if (retry_max_delay_ms <= 0) {
+    throw std::invalid_argument("retry_max_delay_ms must be positive");
+  }
+  if (retry_base_delay_ms > retry_max_delay_ms) {
+    throw std::invalid_argument(
+        "retry_base_delay_ms must not exceed retry_max_delay_ms");
+  }
+  if (token_refresh_threshold < 0.0 || token_refresh_threshold > 1.0) {
+    throw std::invalid_argument(
+        "token_refresh_threshold must be between 0.0 and 1.0");
+  }
+  if (http_timeout_seconds <= 0) {
+    throw std::invalid_argument("http_timeout_seconds must be positive");
+  }
+}
+
+void UamiOAuthProvider::Config::set_identity_pool_ids(
+    const std::vector<std::string>& pool_ids) {
+  if (pool_ids.empty()) {
+    identity_pool_id.clear();
+    return;
+  }
+
+  size_t total_size = 0;
+  for (const auto& s : pool_ids) total_size += s.size();
+  total_size += pool_ids.size() - 1;
+
+  std::string joined;
+  joined.reserve(total_size);
+
+  for (size_t i = 0; i < pool_ids.size(); ++i) {
+    if (i > 0) joined += ",";
+    joined += pool_ids[i];
+  }
+  identity_pool_id = std::move(joined);
+}
+
+// ============================================================================
+// UamiOAuthProvider Implementation
+// ============================================================================
+
+UamiOAuthProvider::UamiOAuthProvider(const Config& config)
+    : config_(config) {
+  config_.validate();
+}
+
+BearerFields UamiOAuthProvider::get_bearer_fields() {
+  {
+    std::shared_lock<std::shared_mutex> read_lock(mutex_);
+    if (token_.is_valid() &&
+        !token_.is_expired(config_.token_refresh_threshold)) {
+      return BearerFields{token_.access_token, config_.logical_cluster,
+                          config_.identity_pool_id};
+    }
+  }
+
+  std::unique_lock<std::shared_mutex> write_lock(mutex_);
+  if (token_.is_valid() &&
+      !token_.is_expired(config_.token_refresh_threshold)) {
+    return BearerFields{token_.access_token, config_.logical_cluster,
+                        config_.identity_pool_id};
+  }
+
+  OAuthToken new_token = fetch_token();
+  token_ = std::move(new_token);
+
+  return BearerFields{token_.access_token, config_.logical_cluster,
+                      config_.identity_pool_id};
+}
+
+void UamiOAuthProvider::invalidate_token() {
+  std::unique_lock<std::shared_mutex> lock(mutex_);
+  token_ = OAuthToken{};
+}
+
+OAuthToken UamiOAuthProvider::fetch_token() {
+  std::string url = config_.uami_url + config_.uami_endpoint_query;
+
+  int attempt = 0;
+  while (true) {
+    auto response = cpr::Get(
+        cpr::Url{url},
+        cpr::Header{{"Metadata", "true"}},
+        cpr::Timeout{std::chrono::seconds(config_.http_timeout_seconds)});
+
+    if (response.status_code >= 200 && response.status_code < 300) {
+      try {
+        auto json_response = json::parse(response.text);
+
+        if (!json_response.contains("access_token")) {
+          throw std::runtime_error(
+              "UAMI token response missing 'access_token' field");
+        }
+
+        OAuthToken token;
+        token.access_token = json_response["access_token"].get<std::string>();
+        // Azure IMDS returns expires_in as a string (e.g., "3599")
+        if (json_response.contains("expires_in")) {
+          auto& val = json_response["expires_in"];
+          if (val.is_string()) {
+            token.expires_in_seconds = std::stoi(val.get<std::string>());
+          } else {
+            token.expires_in_seconds = val.get<int>();
+          }
+        } else {
+          token.expires_in_seconds = 3600;
+        }
+        token.expires_at = std::chrono::system_clock::now() +
+                           std::chrono::seconds(token.expires_in_seconds);
+        return token;
+      } catch (const json::exception& e) {
+        throw std::runtime_error(
+            "Failed to parse UAMI token response: " + std::string(e.what()));
+      }
+    }
+
+    bool should_retry = false;
+    if (response.status_code == 0) {
+      should_retry = true;
+    } else if (response.status_code >= 400) {
+      should_retry = utils::isRetriable(response.status_code);
+    }
+
+    if (!should_retry || attempt >= config_.max_retries) {
+      std::ostringstream error_msg;
+      error_msg << "UAMI token request failed with status "
+                << response.status_code;
+      if (!response.text.empty()) {
+        error_msg << ": " << response.text;
+      }
+      throw std::runtime_error(error_msg.str());
+    }
+
+    auto delay = utils::calculateExponentialBackoff(
+        config_.retry_base_delay_ms, attempt,
+        std::chrono::milliseconds(config_.retry_max_delay_ms));
+    std::this_thread::sleep_for(delay);
+    attempt++;
+  }
+}
+
 }  // namespace schemaregistry::rest

--- a/src/rest/OAuthProvider.cpp
+++ b/src/rest/OAuthProvider.cpp
@@ -1,10 +1,9 @@
 /**
- * OAuth 2.0 Provider Implementation
+ * OAuth 2.0 Base Provider Implementation
  */
 
 #include "schemaregistry/rest/OAuthProvider.h"
 
-#include <cpr/cpr.h>
 #include <nlohmann/json.hpp>
 
 #include <chrono>
@@ -14,27 +13,13 @@
 
 #include "schemaregistry/rest/BackoffUtils.h"
 
-using json = nlohmann::json;
-
 namespace schemaregistry::rest {
 
 // ============================================================================
-// OAuthClientProvider::Config Implementation
+// CachingOAuthProvider::CacheConfig Implementation
 // ============================================================================
 
-void OAuthClientProvider::Config::validate() const {
-  if (client_id.empty()) {
-    throw std::invalid_argument("client_id is required");
-  }
-  if (client_secret.empty()) {
-    throw std::invalid_argument("client_secret is required");
-  }
-  if (scope.empty()) {
-    throw std::invalid_argument("scope is required");
-  }
-  if (token_endpoint_url.empty()) {
-    throw std::invalid_argument("token_endpoint_url is required");
-  }
+void CachingOAuthProvider::CacheConfig::validate() const {
   if (max_retries < 0) {
     throw std::invalid_argument("max_retries must be non-negative");
   }
@@ -58,266 +43,50 @@ void OAuthClientProvider::Config::validate() const {
 }
 
 // ============================================================================
-// OAuthClientProvider Implementation
+// CachingOAuthProvider Implementation
 // ============================================================================
 
-OAuthClientProvider::OAuthClientProvider(const Config& config)
-    : config_(config) {
-  config_.validate();
-}
+CachingOAuthProvider::CachingOAuthProvider(const CacheConfig& cache_config)
+    : cache_config_(cache_config) {}
 
-BearerFields OAuthClientProvider::get_bearer_fields() {
-  // Check if existing lock is valid
-  // Use shared lock for concurrent reads
+BearerFields CachingOAuthProvider::get_bearer_fields() {
   {
     std::shared_lock<std::shared_mutex> read_lock(mutex_);
     if (token_.is_valid() &&
-        !token_.is_expired(config_.token_refresh_threshold)) {
-      return BearerFields{token_.access_token, config_.logical_cluster,
-                          config_.identity_pool_id};
-    }
-  }
-
-  // Refresh token if expired or not present
-  // Use exclusive lock to prevent multiple threads fetching new token simultaneously
-  std::unique_lock<std::shared_mutex> write_lock(mutex_);
-  if (token_.is_valid() &&
-      !token_.is_expired(config_.token_refresh_threshold)) {
-    return BearerFields{token_.access_token, config_.logical_cluster,
-                        config_.identity_pool_id};
-  }
-
-  OAuthToken new_token = fetch_token();
-  token_ = std::move(new_token);
-
-  return BearerFields{token_.access_token, config_.logical_cluster,
-                      config_.identity_pool_id};
-}
-
-void OAuthClientProvider::invalidate_token() {
-  std::unique_lock<std::shared_mutex> lock(mutex_);
-  token_ = OAuthToken{};
-}
-
-OAuthToken OAuthClientProvider::fetch_token() {
-  // Build form-encoded body for OAuth client credentials grant
-  cpr::Payload payload{{"grant_type", "client_credentials"},
-                       {"client_id", config_.client_id},
-                       {"client_secret", config_.client_secret},
-                       {"scope", config_.scope}};
-
-  int attempt = 0;
-  while (true) {
-    auto response = cpr::Post(
-        cpr::Url{config_.token_endpoint_url}, payload,
-        cpr::Header{{"Content-Type", "application/x-www-form-urlencoded"}},
-        cpr::Timeout{std::chrono::seconds(config_.http_timeout_seconds)});
-
-    // Success: parse and return token
-    if (response.status_code >= 200 && response.status_code < 300) {
-      try {
-        auto json_response = json::parse(response.text);
-
-        if (!json_response.contains("access_token")) {
-          throw std::runtime_error(
-              "OAuth token response missing 'access_token' field");
-        }
-
-        OAuthToken token;
-        token.access_token = json_response["access_token"].get<std::string>();
-        token.expires_in_seconds = json_response.value("expires_in", 3600);
-        token.expires_at = std::chrono::system_clock::now() +
-                           std::chrono::seconds(token.expires_in_seconds);
-        return token;
-      } catch (const json::exception& e) {
-        // JSON parsing error on 2xx - not retriable
-        throw std::runtime_error(
-            "Failed to parse OAuth token response: " + std::string(e.what()));
-      }
-    }
-
-    // Check if we should retry
-    bool should_retry = false;
-    if (response.status_code == 0) {
-      // Network error - always retriable
-      should_retry = true;
-    } else if (response.status_code >= 400) {
-      should_retry = utils::isRetriable(response.status_code);
-    }
-
-    if (!should_retry || attempt >= config_.max_retries) {
-      std::ostringstream error_msg;
-      error_msg << "OAuth token request failed with status "
-                << response.status_code;
-      if (!response.text.empty()) {
-        error_msg << ": " << response.text;
-      }
-      throw std::runtime_error(error_msg.str());
-    }
-
-    // Retry with backoff
-    auto delay = utils::calculateExponentialBackoff(
-        config_.retry_base_delay_ms, attempt,
-        std::chrono::milliseconds(config_.retry_max_delay_ms));
-    std::this_thread::sleep_for(delay);
-    attempt++;
-  }
-}
-
-// ============================================================================
-// CustomOAuthProvider Implementation
-// ============================================================================
-
-CustomOAuthProvider::CustomOAuthProvider(TokenFetchFunction fetch_fn,
-                                         std::string logical_cluster,
-                                         std::string identity_pool_id)
-    : fetch_fn_(std::move(fetch_fn)),
-      logical_cluster_(std::move(logical_cluster)),
-      identity_pool_id_(std::move(identity_pool_id)) {
-  if (!fetch_fn_) {
-    throw std::invalid_argument("fetch_fn cannot be empty");
-  }
-}
-
-BearerFields CustomOAuthProvider::get_bearer_fields() {
-  // Call the custom function to get access token
-  std::string access_token = fetch_fn_();
-
-  if (access_token.empty()) {
-    throw std::runtime_error("Custom token fetch function returned empty token");
-  }
-
-  return BearerFields{std::move(access_token), logical_cluster_, identity_pool_id_};
-}
-
-// ============================================================================
-// UamiOAuthProvider::Config Implementation
-// ============================================================================
-
-void UamiOAuthProvider::Config::validate() const {
-  if (uami_endpoint_query.empty()) {
-    throw std::invalid_argument("uami_endpoint_query is required");
-  }
-  if (max_retries < 0) {
-    throw std::invalid_argument("max_retries must be non-negative");
-  }
-  if (retry_base_delay_ms <= 0) {
-    throw std::invalid_argument("retry_base_delay_ms must be positive");
-  }
-  if (retry_max_delay_ms <= 0) {
-    throw std::invalid_argument("retry_max_delay_ms must be positive");
-  }
-  if (retry_base_delay_ms > retry_max_delay_ms) {
-    throw std::invalid_argument(
-        "retry_base_delay_ms must not exceed retry_max_delay_ms");
-  }
-  if (token_refresh_threshold < 0.0 || token_refresh_threshold > 1.0) {
-    throw std::invalid_argument(
-        "token_refresh_threshold must be between 0.0 and 1.0");
-  }
-  if (http_timeout_seconds <= 0) {
-    throw std::invalid_argument("http_timeout_seconds must be positive");
-  }
-}
-
-void UamiOAuthProvider::Config::set_identity_pool_ids(
-    const std::vector<std::string>& pool_ids) {
-  if (pool_ids.empty()) {
-    identity_pool_id.clear();
-    return;
-  }
-
-  size_t total_size = 0;
-  for (const auto& s : pool_ids) total_size += s.size();
-  total_size += pool_ids.size() - 1;
-
-  std::string joined;
-  joined.reserve(total_size);
-
-  for (size_t i = 0; i < pool_ids.size(); ++i) {
-    if (i > 0) joined += ",";
-    joined += pool_ids[i];
-  }
-  identity_pool_id = std::move(joined);
-}
-
-// ============================================================================
-// UamiOAuthProvider Implementation
-// ============================================================================
-
-UamiOAuthProvider::UamiOAuthProvider(const Config& config)
-    : config_(config) {
-  config_.validate();
-}
-
-BearerFields UamiOAuthProvider::get_bearer_fields() {
-  {
-    std::shared_lock<std::shared_mutex> read_lock(mutex_);
-    if (token_.is_valid() &&
-        !token_.is_expired(config_.token_refresh_threshold)) {
-      return BearerFields{token_.access_token, config_.logical_cluster,
-                          config_.identity_pool_id};
+        !token_.is_expired(cache_config_.token_refresh_threshold)) {
+      return BearerFields{token_.access_token, cache_config_.logical_cluster,
+                          cache_config_.identity_pool_id};
     }
   }
 
   std::unique_lock<std::shared_mutex> write_lock(mutex_);
   if (token_.is_valid() &&
-      !token_.is_expired(config_.token_refresh_threshold)) {
-    return BearerFields{token_.access_token, config_.logical_cluster,
-                        config_.identity_pool_id};
+      !token_.is_expired(cache_config_.token_refresh_threshold)) {
+    return BearerFields{token_.access_token, cache_config_.logical_cluster,
+                        cache_config_.identity_pool_id};
   }
 
   OAuthToken new_token = fetch_token();
   token_ = std::move(new_token);
 
-  return BearerFields{token_.access_token, config_.logical_cluster,
-                      config_.identity_pool_id};
+  return BearerFields{token_.access_token, cache_config_.logical_cluster,
+                      cache_config_.identity_pool_id};
 }
 
-void UamiOAuthProvider::invalidate_token() {
+void CachingOAuthProvider::invalidate_token() {
   std::unique_lock<std::shared_mutex> lock(mutex_);
   token_ = OAuthToken{};
 }
 
-OAuthToken UamiOAuthProvider::fetch_token() {
-  std::string url = config_.uami_url + config_.uami_endpoint_query;
-
+std::string CachingOAuthProvider::fetch_with_retry(
+    const std::string& provider_name,
+    const std::function<TokenResponse()>& make_request) {
   int attempt = 0;
   while (true) {
-    auto response = cpr::Get(
-        cpr::Url{url},
-        cpr::Header{{"Metadata", "true"}},
-        cpr::Timeout{std::chrono::seconds(config_.http_timeout_seconds)});
+    auto response = make_request();
 
     if (response.status_code >= 200 && response.status_code < 300) {
-      try {
-        auto json_response = json::parse(response.text);
-
-        if (!json_response.contains("access_token")) {
-          throw std::runtime_error(
-              "UAMI token response missing 'access_token' field");
-        }
-
-        OAuthToken token;
-        token.access_token = json_response["access_token"].get<std::string>();
-        // Azure IMDS returns expires_in as a string (e.g., "3599")
-        if (json_response.contains("expires_in")) {
-          auto& val = json_response["expires_in"];
-          if (val.is_string()) {
-            token.expires_in_seconds = std::stoi(val.get<std::string>());
-          } else {
-            token.expires_in_seconds = val.get<int>();
-          }
-        } else {
-          token.expires_in_seconds = 3600;
-        }
-        token.expires_at = std::chrono::system_clock::now() +
-                           std::chrono::seconds(token.expires_in_seconds);
-        return token;
-      } catch (const json::exception& e) {
-        throw std::runtime_error(
-            "Failed to parse UAMI token response: " + std::string(e.what()));
-      }
+      return response.text;
     }
 
     bool should_retry = false;
@@ -327,9 +96,9 @@ OAuthToken UamiOAuthProvider::fetch_token() {
       should_retry = utils::isRetriable(response.status_code);
     }
 
-    if (!should_retry || attempt >= config_.max_retries) {
+    if (!should_retry || attempt >= cache_config_.max_retries) {
       std::ostringstream error_msg;
-      error_msg << "UAMI token request failed with status "
+      error_msg << provider_name << " token request failed with status "
                 << response.status_code;
       if (!response.text.empty()) {
         error_msg << ": " << response.text;
@@ -338,11 +107,29 @@ OAuthToken UamiOAuthProvider::fetch_token() {
     }
 
     auto delay = utils::calculateExponentialBackoff(
-        config_.retry_base_delay_ms, attempt,
-        std::chrono::milliseconds(config_.retry_max_delay_ms));
+        cache_config_.retry_base_delay_ms, attempt,
+        std::chrono::milliseconds(cache_config_.retry_max_delay_ms));
     std::this_thread::sleep_for(delay);
     attempt++;
   }
+}
+
+OAuthToken CachingOAuthProvider::parse_standard_token_response(
+    const std::string& json_text, const std::string& provider_name) {
+  using json = nlohmann::json;
+  auto json_response = json::parse(json_text);
+
+  if (!json_response.contains("access_token")) {
+    throw std::runtime_error(
+        provider_name + " token response missing 'access_token' field");
+  }
+
+  OAuthToken token;
+  token.access_token = json_response["access_token"].get<std::string>();
+  token.expires_in_seconds = json_response.value("expires_in", 3600);
+  token.expires_at = std::chrono::system_clock::now() +
+                     std::chrono::seconds(token.expires_in_seconds);
+  return token;
 }
 
 }  // namespace schemaregistry::rest

--- a/src/rest/UamiOAuthProvider.cpp
+++ b/src/rest/UamiOAuthProvider.cpp
@@ -1,0 +1,76 @@
+/**
+ * Azure UAMI OAuth Provider Implementation
+ */
+
+#include "schemaregistry/rest/UamiOAuthProvider.h"
+
+#include <cpr/cpr.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+using json = nlohmann::json;
+
+namespace schemaregistry::rest {
+
+// ============================================================================
+// UamiOAuthProvider::Config Implementation
+// ============================================================================
+
+void UamiOAuthProvider::Config::validate() const {
+  if (uami_endpoint_query.empty()) {
+    throw std::invalid_argument("uami_endpoint_query is required");
+  }
+  CacheConfig::validate();
+}
+
+// ============================================================================
+// UamiOAuthProvider Implementation
+// ============================================================================
+
+UamiOAuthProvider::UamiOAuthProvider(const Config& config)
+    : CachingOAuthProvider(config), config_(config) {
+  config_.validate();
+}
+
+OAuthToken UamiOAuthProvider::fetch_token() {
+  std::string url = config_.uami_url + config_.uami_endpoint_query;
+
+  std::string response_text = fetch_with_retry(
+      "UAMI",
+      [&]() -> TokenResponse {
+        auto r = cpr::Get(
+            cpr::Url{url},
+            cpr::Header{{"Metadata", "true"}},
+            cpr::Timeout{std::chrono::seconds(cache_config_.http_timeout_seconds)});
+        return {static_cast<int>(r.status_code), r.text};
+      });
+
+  auto json_response = json::parse(response_text);
+
+  if (!json_response.contains("access_token")) {
+    throw std::runtime_error(
+        "UAMI token response missing 'access_token' field");
+  }
+
+  OAuthToken token;
+  token.access_token = json_response["access_token"].get<std::string>();
+  // Azure IMDS returns expires_in as a string (e.g., "3599")
+  if (json_response.contains("expires_in")) {
+    auto& val = json_response["expires_in"];
+    if (val.is_string()) {
+      token.expires_in_seconds = std::stoi(val.get<std::string>());
+    } else {
+      token.expires_in_seconds = val.get<int>();
+    }
+  } else {
+    token.expires_in_seconds = 3600;
+  }
+  token.expires_at = std::chrono::system_clock::now() +
+                     std::chrono::seconds(token.expires_in_seconds);
+  return token;
+}
+
+}  // namespace schemaregistry::rest

--- a/test/OAuthProviderTest.cpp
+++ b/test/OAuthProviderTest.cpp
@@ -247,6 +247,96 @@ TEST(BearerFieldsTest, ParameterizedConstructor) {
 }
 
 // =============================================================================
+// UamiOAuthProvider::Config Tests
+// =============================================================================
+
+TEST(UamiConfigTest, ValidConfigPasses) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01&resource=https://confluent.cloud&client_id=test-id";
+  config.logical_cluster = "lsrc-123";
+  config.identity_pool_id = "pool-456";
+
+  EXPECT_NO_THROW(config.validate());
+}
+
+TEST(UamiConfigTest, DefaultUamiUrl) {
+  UamiOAuthProvider::Config config;
+  EXPECT_EQ(config.uami_url, "http://169.254.169.254/metadata/identity/oauth2/token");
+}
+
+TEST(UamiConfigTest, ThrowsOnMissingQueryUrl) {
+  UamiOAuthProvider::Config config;
+  // uami_endpoint_query is empty
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ThrowsOnNegativeRetries) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.max_retries = -1;
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ThrowsOnInvalidThreshold) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.token_refresh_threshold = 1.5;
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ThrowsOnBaseDelayExceedsMaxDelay) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.retry_base_delay_ms = 5000;
+  config.retry_max_delay_ms = 1000;
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ThrowsOnInvalidBaseDelay) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.retry_base_delay_ms = 0;
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ThrowsOnInvalidHttpTimeout) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.http_timeout_seconds = 0;
+
+  EXPECT_THROW(config.validate(), std::invalid_argument);
+}
+
+TEST(UamiConfigTest, DefaultValuesMatch) {
+  UamiOAuthProvider::Config config;
+
+  EXPECT_EQ(config.max_retries, 3);
+  EXPECT_EQ(config.retry_base_delay_ms, 1000);
+  EXPECT_EQ(config.retry_max_delay_ms, 20000);
+  EXPECT_DOUBLE_EQ(config.token_refresh_threshold, 0.8);
+  EXPECT_EQ(config.http_timeout_seconds, 30);
+}
+
+TEST(UamiConfigTest, ConstructionValidatesConfig) {
+  UamiOAuthProvider::Config config;
+  // uami_endpoint_query is empty - should throw on construction
+
+  EXPECT_THROW({ UamiOAuthProvider provider(config); }, std::invalid_argument);
+}
+
+TEST(UamiConfigTest, ConstructionSucceedsWithValidConfig) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+
+  EXPECT_NO_THROW({ UamiOAuthProvider provider(config); });
+}
+
+// =============================================================================
 // Polymorphism Tests (verifies all providers work through base interface)
 // =============================================================================
 
@@ -265,4 +355,18 @@ TEST(PolymorphismTest, AllProvidersWorkThroughBaseInterface) {
   EXPECT_EQ(fields.access_token, "custom-token");
   EXPECT_EQ(fields.logical_cluster, "lsrc-222");
   EXPECT_EQ(fields.identity_pool_id, "pool-222");
+}
+
+TEST(PolymorphismTest, UamiProviderWorksAsOAuthProvider) {
+  UamiOAuthProvider::Config config;
+  config.uami_endpoint_query = "?api-version=2018-02-01";
+  config.logical_cluster = "lsrc-333";
+  config.identity_pool_id = "pool-333";
+
+  std::shared_ptr<OAuthProvider> provider =
+      std::make_shared<UamiOAuthProvider>(config);
+
+  // Can't call get_bearer_fields() without a real IMDS endpoint,
+  // but verify it compiles and constructs through the base interface
+  EXPECT_NE(provider, nullptr);
 }

--- a/test/OAuthProviderTest.cpp
+++ b/test/OAuthProviderTest.cpp
@@ -7,6 +7,9 @@
 #include <chrono>
 #include <thread>
 #include "schemaregistry/rest/OAuthProvider.h"
+#include "schemaregistry/rest/OAuthClientProvider.h"
+#include "schemaregistry/rest/CustomOAuthProvider.h"
+#include "schemaregistry/rest/UamiOAuthProvider.h"
 
 using namespace schemaregistry::rest;
 


### PR DESCRIPTION
Add UamiOAuthProvider class that fetches OAuth tokens from the Azure Instance Metadata Service (IMDS) using User-Assigned Managed Identities. Reuses the existing token caching (double-checked locking with shared_mutex) and retry/backoff mechanisms. Handles Azure IMDS returning expires_in as a string. Includes config validation tests and a standalone runnable example.

DGS-23746

Tested on Azure VM