### PR TITLE
Reapply "DGS-23477: Make identity pool id header optional (#18)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-* Make identity pool id header optional, with union-of-pools support (#29)
+* Make identity pool id header optional, with union-of-pools support (#30)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.x.x
 
+## Enhancements
+
+* Make identity pool id header optional, with union-of-pools support (#29)
+
 ## Fixes
 
 * Handle anyOf/allOf in JSON transforms (#28)

--- a/example/OAuthSchemaRegistry.cpp
+++ b/example/OAuthSchemaRegistry.cpp
@@ -1,12 +1,14 @@
 /**
  * Examples of setting up Schema Registry with OAuth using static token
- * and Client Credentials flow
+ * and Client Credentials flow, including optional identity pool and
+ * union-of-pools support.
  */
 
 #include <iostream>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "schemaregistry/rest/ClientConfiguration.h"
 #include "schemaregistry/rest/CustomOAuthProvider.h"
@@ -53,6 +55,69 @@ int main() {
     auto client = SchemaRegistryClient::newClient(config);
     auto subjects = client->getAllSubjects();
     std::cout << "OAuth client credentials: Found " << subjects.size() << " subjects" << std::endl;
+  }
+
+  // Example 2.1b: No identity pool (auto pool mapping)
+  {
+    OAuthClientProvider::Config oauth_config;
+    oauth_config.client_id = "client-id";
+    oauth_config.client_secret = "client-secret";
+    oauth_config.scope = "schema_registry";
+    oauth_config.token_endpoint_url = "https://yourauthprovider.com/v1/token";
+    oauth_config.logical_cluster = "lsrc-12345";
+    // identity_pool_id left empty -- header is omitted, server uses auto pool mapping
+
+    auto provider = std::make_shared<OAuthClientProvider>(oauth_config);
+
+    auto config = std::make_shared<ClientConfiguration>(
+        std::vector<std::string>{"https://psrc-123456.us-east-1.aws.confluent.cloud"});
+    config->setOAuthProvider(provider);
+
+    auto client = SchemaRegistryClient::newClient(config);
+    auto subjects = client->getAllSubjects();
+    std::cout << "Auto pool mapping: Found " << subjects.size() << " subjects" << std::endl;
+  }
+
+  // Example 2.1c: Union-of-pools via comma-separated string
+  {
+    OAuthClientProvider::Config oauth_config;
+    oauth_config.client_id = "client-id";
+    oauth_config.client_secret = "client-secret";
+    oauth_config.scope = "schema_registry";
+    oauth_config.token_endpoint_url = "https://yourauthprovider.com/v1/token";
+    oauth_config.logical_cluster = "lsrc-12345";
+    oauth_config.identity_pool_id = "pool-1,pool-2,pool-3";
+
+    auto provider = std::make_shared<OAuthClientProvider>(oauth_config);
+
+    auto config = std::make_shared<ClientConfiguration>(
+        std::vector<std::string>{"https://psrc-123456.us-east-1.aws.confluent.cloud"});
+    config->setOAuthProvider(provider);
+
+    auto client = SchemaRegistryClient::newClient(config);
+    auto subjects = client->getAllSubjects();
+    std::cout << "Union of pools (string): Found " << subjects.size() << " subjects" << std::endl;
+  }
+
+  // Example 2.1d: Union-of-pools from a vector (if you have a list)
+  {
+    OAuthClientProvider::Config oauth_config;
+    oauth_config.client_id = "client-id";
+    oauth_config.client_secret = "client-secret";
+    oauth_config.scope = "schema_registry";
+    oauth_config.token_endpoint_url = "https://yourauthprovider.com/v1/token";
+    oauth_config.logical_cluster = "lsrc-12345";
+    oauth_config.set_identity_pool_ids({"pool-1", "pool-2", "pool-3"});
+
+    auto provider = std::make_shared<OAuthClientProvider>(oauth_config);
+
+    auto config = std::make_shared<ClientConfiguration>(
+        std::vector<std::string>{"https://psrc-123456.us-east-1.aws.confluent.cloud"});
+    config->setOAuthProvider(provider);
+
+    auto client = SchemaRegistryClient::newClient(config);
+    auto subjects = client->getAllSubjects();
+    std::cout << "Union of pools (vector): Found " << subjects.size() << " subjects" << std::endl;
   }
 
   // Example 2.2: OAuth Client Credentials (factory pattern)

--- a/include/schemaregistry/rest/OAuthProvider.h
+++ b/include/schemaregistry/rest/OAuthProvider.h
@@ -23,16 +23,17 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <vector>
 
 namespace schemaregistry::rest {
 
 /**
  * Bearer authentication fields required for Confluent Cloud Schema Registry.
  *
- * Confluent Cloud requires three fields:
+ * Fields:
  * - access_token: OAuth bearer token
  * - logical_cluster: Schema Registry logical cluster ID (e.g., "lsrc-12345"). Required for Confluent Cloud
- * - identity_pool_id: Identity pool ID (e.g., "pool-abcd"). Required for Confluent Cloud
+ * - identity_pool_id: Identity pool ID (e.g., "pool-abcd"). Optional; when omitted the header is not sent and the server uses auto pool mapping.
  */
 struct BearerFields {
   std::string access_token;
@@ -110,6 +111,10 @@ class CachingOAuthProvider : public OAuthProvider {
  public:
   struct CacheConfig {
     std::string logical_cluster;
+    // Identity pool ID(s) are optional. May contain a single pool ID, a
+    // comma-separated list (union of pools), or be set from a vector via
+    // set_identity_pool_ids(). When empty, the Confluent-Identity-Pool-Id
+    // header is omitted and the server uses auto pool mapping.
     std::string identity_pool_id;
 
     int max_retries{3};
@@ -119,6 +124,15 @@ class CachingOAuthProvider : public OAuthProvider {
     int http_timeout_seconds{30};
 
     void validate() const;
+
+    /**
+     * Set identity pool ID(s) from a vector of pool IDs.
+     *
+     * Joins the entries with commas and stores the result in identity_pool_id.
+     *
+     * @param pool_ids Vector of identity pool ID strings
+     */
+    void set_identity_pool_ids(const std::vector<std::string>& pool_ids);
   };
 
   BearerFields get_bearer_fields() override;

--- a/src/rest/OAuthProvider.cpp
+++ b/src/rest/OAuthProvider.cpp
@@ -42,6 +42,27 @@ void CachingOAuthProvider::CacheConfig::validate() const {
   }
 }
 
+void CachingOAuthProvider::CacheConfig::set_identity_pool_ids(
+    const std::vector<std::string>& pool_ids) {
+  if (pool_ids.empty()) {
+    identity_pool_id.clear();
+    return;
+  }
+
+  size_t total_size = 0;
+  for (const auto& s : pool_ids) total_size += s.size();
+  total_size += pool_ids.size() - 1;  // for commas
+
+  std::string joined;
+  joined.reserve(total_size);
+
+  for (size_t i = 0; i < pool_ids.size(); ++i) {
+    if (i > 0) joined += ",";
+    joined += pool_ids[i];
+  }
+  identity_pool_id = std::move(joined);
+}
+
 // ============================================================================
 // CachingOAuthProvider Implementation
 // ============================================================================

--- a/test/OAuthProviderTest.cpp
+++ b/test/OAuthProviderTest.cpp
@@ -5,7 +5,9 @@
 
 #include <gtest/gtest.h>
 #include <chrono>
+#include <string>
 #include <thread>
+#include <vector>
 #include "schemaregistry/rest/OAuthProvider.h"
 #include "schemaregistry/rest/OAuthClientProvider.h"
 #include "schemaregistry/rest/CustomOAuthProvider.h"
@@ -78,6 +80,42 @@ TEST(OAuthClientConfigTest, ValidConfigPasses) {
   config.identity_pool_id = "pool-456";
 
   EXPECT_NO_THROW(config.validate());
+}
+
+TEST(OAuthClientConfigTest, ValidConfigWithoutIdentityPool) {
+  // identity_pool_id is optional; when omitted the header is simply not sent
+  // and the server uses auto pool mapping.
+  OAuthClientProvider::Config config;
+  config.client_id = "client-id";
+  config.client_secret = "client-secret";
+  config.scope = "schema_registry";
+  config.token_endpoint_url = "https://idp.example.com/token";
+  config.logical_cluster = "lsrc-123";
+
+  EXPECT_NO_THROW(config.validate());
+  EXPECT_TRUE(config.identity_pool_id.empty());
+}
+
+TEST(OAuthClientConfigTest, SetIdentityPoolIdsJoinsWithCommas) {
+  OAuthClientProvider::Config config;
+  config.set_identity_pool_ids({"pool-1", "pool-2", "pool-3"});
+  EXPECT_EQ(config.identity_pool_id, "pool-1,pool-2,pool-3");
+}
+
+TEST(OAuthClientConfigTest, SetIdentityPoolIdsEmptyClearsValue) {
+  OAuthClientProvider::Config config;
+  config.identity_pool_id = "pool-existing";
+  config.set_identity_pool_ids({});
+  EXPECT_TRUE(config.identity_pool_id.empty());
+}
+
+TEST(CustomOAuthProviderTest, WorksWithCommaSeparatedPools) {
+  auto provider = std::make_shared<CustomOAuthProvider>(
+      []() { return "custom-token"; }, "lsrc-123", "pool-a,pool-b");
+
+  auto fields = provider->get_bearer_fields();
+  EXPECT_EQ(fields.access_token, "custom-token");
+  EXPECT_EQ(fields.identity_pool_id, "pool-a,pool-b");
 }
 
 TEST(OAuthClientConfigTest, ThrowsOnMissingClientId) {


### PR DESCRIPTION
This reverts commit 508e817a37af98ee330927aecfac7989b2972b87 (#26),
reapplying the optional identity pool id header and union-of-pools
support, adapted to the refactored OAuth provider structure
(set_identity_pool_ids now lives on CachingOAuthProvider::CacheConfig).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
