### PR TITLE
Fix Protobuf deserializer's use of default template parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 * Handle anyOf/allOf in JSON transforms (#28)
+* Fix Protobuf deserializer's use of default template parameter (#33)
 
 
 # 0.1.3

--- a/include/schemaregistry/serdes/protobuf/ProtobufDeserializer.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufDeserializer.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -314,21 +315,32 @@ inline std::unique_ptr<T> ProtobufDeserializer<T>::deserialize(
     if (proto_variant.type != ProtobufVariant::ValueType::Message) {
         throw ProtobufError("Expected message variant but got different type");
     }
-    google::protobuf::Message &final_msg =
-        *proto_variant
-             .template get<std::unique_ptr<google::protobuf::Message>>();
-    auto out_msg = std::make_unique<T>();
 
-    // Don't use CopyFrom, as the descriptors are from different pools
-    std::string serialized_data;
-    if (final_msg.SerializeToString(&serialized_data)) {
-        // Deserialize into the specific message type
-        if (!out_msg->ParseFromString(serialized_data)) {
-            throw ProtobufError("Failed to parse protobuf message");
+    if constexpr (std::is_same_v<T, google::protobuf::Message>) {
+        // Generic/dynamic mode (T is the default, abstract google::protobuf::Message):
+        // there is no concrete message type to bridge into, so hand back the
+        // already fully-resolved dynamic message as-is.
+        auto &result_msg =
+            proto_variant
+                .template get<std::unique_ptr<google::protobuf::Message>>();
+        return std::move(result_msg);
+    } else {
+        google::protobuf::Message &final_msg =
+            *proto_variant
+                 .template get<std::unique_ptr<google::protobuf::Message>>();
+        auto out_msg = std::make_unique<T>();
+
+        // Don't use CopyFrom, as the descriptors are from different pools
+        std::string serialized_data;
+        if (final_msg.SerializeToString(&serialized_data)) {
+            // Deserialize into the specific message type
+            if (!out_msg->ParseFromString(serialized_data)) {
+                throw ProtobufError("Failed to parse protobuf message");
+            }
         }
-    }
 
-    return out_msg;
+        return out_msg;
+    }
 }
 
 template <typename T>

--- a/include/schemaregistry/serdes/protobuf/ProtobufDeserializer.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufDeserializer.h
@@ -47,6 +47,19 @@ class ProtobufDeserializer {
     std::unique_ptr<ProtobufSerde> serde_;
     SubjectNameStrategyFunc subject_name_strategy_;
 
+    // Keyed by the DescriptorPool used to build each factory. A
+    // DynamicMessageFactory owns the reflection "support data" that the
+    // messages it creates depend on for their entire lifetime (per
+    // dynamic_message.h), so it must not be a call-local temporary: it needs
+    // to outlive any message returned to the caller, e.g. via the generic
+    // T = google::protobuf::Message deserialization mode.
+    std::unordered_map<const google::protobuf::DescriptorPool *,
+                       std::unique_ptr<google::protobuf::DynamicMessageFactory>>
+        message_factories_;
+
+    google::protobuf::DynamicMessageFactory &getMessageFactory(
+        const google::protobuf::DescriptorPool *pool);
+
     std::unique_ptr<google::protobuf::Message> createMessageFromDescriptor(
         const google::protobuf::Descriptor *descriptor);
 
@@ -84,6 +97,21 @@ inline std::string ProtobufDeserializer<T>::getRecordName(
         return file_desc->message_type(0)->full_name();
     }
     throw ProtobufError("Could not determine record name from schema");
+}
+
+template <typename T>
+inline google::protobuf::DynamicMessageFactory &
+ProtobufDeserializer<T>::getMessageFactory(
+    const google::protobuf::DescriptorPool *pool) {
+    auto iter = message_factories_.find(pool);
+    if (iter == message_factories_.end()) {
+        iter = message_factories_
+                   .emplace(pool, std::make_unique<
+                                      google::protobuf::DynamicMessageFactory>(
+                                      pool))
+                   .first;
+    }
+    return *iter->second;
 }
 
 template <typename T>
@@ -238,7 +266,8 @@ inline std::unique_ptr<T> ProtobufDeserializer<T>::deserialize(
         reader_desc = same_name;
     }
 
-    google::protobuf::DynamicMessageFactory factory(pool_ptr);
+    google::protobuf::DynamicMessageFactory &factory =
+        getMessageFactory(pool_ptr);
     std::unique_ptr<google::protobuf::Message> msg;
 
     if (!migrations.empty()) {

--- a/test/ProtoTest.cpp
+++ b/test/ProtoTest.cpp
@@ -115,6 +115,63 @@ TEST(ProtobufTest, BasicSerialization) {
     EXPECT_EQ(obj2->oneof_string(), obj.oneof_string());
 }
 
+TEST(ProtobufTest, DynamicDeserialization) {
+    // Create client configuration with mock URL
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    auto client = std::make_shared<MockSchemaRegistryClient>(client_config);
+
+    // Create serializer configuration
+    auto ser_conf = SerializerConfig::createDefault();
+
+    // Create Author object with test data
+    test::Author obj;
+    obj.set_name("Kafka");
+    obj.set_id(123);
+
+    // Create rule registry
+    auto rule_registry = std::make_shared<RuleRegistry>();
+
+    // Create protobuf serializer with default reference subject name strategy
+    ProtobufSerializer<test::Author> ser(
+        client,
+        std::nullopt, // schema
+        rule_registry,
+        ser_conf,
+        defaultReferenceSubjectNameStrategy
+    );
+
+    // Create serialization context
+    SerializationContext ser_ctx;
+    ser_ctx.topic = "test";
+    ser_ctx.serde_type = SerdeType::Value;
+    ser_ctx.serde_format = SerdeFormat::Protobuf;
+    ser_ctx.headers = std::nullopt;
+
+    // Serialize the Author object
+    auto bytes = ser.serialize(ser_ctx, obj);
+
+    // Create a generic/dynamic protobuf deserializer: no concrete message
+    // type is specified, exercising the default `T = google::protobuf::Message`
+    // template parameter.
+    ProtobufDeserializer<> deser(
+        client,
+        rule_registry,
+        DeserializerConfig::createDefault()
+    );
+
+    // Deserialize the bytes back into a dynamically-resolved message.
+    auto obj2_ptr = deser.deserialize(ser_ctx, bytes);
+    ASSERT_NE(obj2_ptr, nullptr);
+
+    // The dynamic message should describe the same type and carry the same
+    // data as the original, even though there's no concrete generated class
+    // to cast to.
+    EXPECT_EQ(obj2_ptr->GetDescriptor()->full_name(),
+              test::Author::descriptor()->full_name());
+    EXPECT_EQ(obj2_ptr->SerializeAsString(), obj.SerializeAsString());
+}
+
 TEST(ProtobufTest, GuidInHeader) {
     // Create client configuration with mock URL
     std::vector<std::string> urls = {"mock://"};


### PR DESCRIPTION
ProtobufDeserializer declares `template <typename T = google::protobuf::Message>`, implying `ProtobufDeserializer<> `should work as a generic/dynamic deserialization mode. But `deserialize()` unconditionally executed `std::make_unique<T>()` before parsing into it — which fails to compile when `T` is the abstract `google::protobuf::Message` base class, since it can't be instantiated. There was no specialization handling this case, so the advertised default was non-functional.