### PR TITLE
DGS-24222 Add support for inline validation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Make identity pool id header optional, with union-of-pools support (#30)
 * Add support for saving Azure key version with DEK (#31)
 * Pass context when clients make KEK calls to DEK Registry (#32)
+* Add support for inline validation rules (#34)
 
 ## Fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if (SCHEMAREGISTRY_WITH_RULES)
     FetchContent_Declare(
         protovalidate_cc
         GIT_REPOSITORY https://github.com/bufbuild/protovalidate-cc.git
-        GIT_TAG        v1.0.0
+        GIT_TAG        v1.1.0
     )
     FetchContent_MakeAvailable(protovalidate_cc)
 endif()
@@ -205,6 +205,7 @@ file(GLOB CORE_SERDES_HEADERS "include/schemaregistry/serdes/Serde.h"
                               "include/schemaregistry/serdes/SerdeError.h"
                               "include/schemaregistry/serdes/SerdeTypes.h"
                               "include/schemaregistry/serdes/RuleRegistry.h"
+                              "include/schemaregistry/serdes/ValidationRule.h"
                               "include/schemaregistry/serdes/WildcardMatcher.h"
                               "src/internal/schemaregistry/serdes/json/JsonValue.h")
 file(GLOB CORE_SERDES_SOURCES "src/serdes/Serde.cpp"
@@ -212,6 +213,7 @@ file(GLOB CORE_SERDES_SOURCES "src/serdes/Serde.cpp"
                               "src/serdes/SerdeError.cpp"
                               "src/serdes/SerdeTypes.cpp"
                               "src/serdes/RuleRegistry.cpp"
+                              "src/serdes/ValidationRule.cpp"
                               "src/serdes/WildcardMatcher.cpp"
                               "src/serdes/json/JsonValue.cpp")
 target_sources(schemaregistry PRIVATE ${CORE_SERDES_HEADERS} ${CORE_SERDES_SOURCES})

--- a/include/schemaregistry/rules/cel/CelExecutor.h
+++ b/include/schemaregistry/rules/cel/CelExecutor.h
@@ -31,6 +31,7 @@ class CelExecutor : public RuleExecutor {
 
   private:
     friend class CelFieldExecutor;
+    friend class CelValidator;
     class Impl;
     std::unique_ptr<Impl> impl_;
 };

--- a/include/schemaregistry/rules/cel/CelValidator.h
+++ b/include/schemaregistry/rules/cel/CelValidator.h
@@ -8,7 +8,10 @@
 
 namespace schemaregistry::rules::cel {
 
-using namespace schemaregistry::serdes;
+using schemaregistry::serdes::SerdeValue;
+using schemaregistry::serdes::ValidationRule;
+using schemaregistry::serdes::ValidationRuleExecutor;
+using schemaregistry::serdes::ValidationRuleResult;
 
 /**
  * Validation-rule executor backed by CEL. The rule expression is evaluated with

--- a/include/schemaregistry/rules/cel/CelValidator.h
+++ b/include/schemaregistry/rules/cel/CelValidator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "schemaregistry/rules/cel/CelExecutor.h"
+#include "schemaregistry/serdes/ValidationRule.h"
+
+namespace schemaregistry::rules::cel {
+
+using namespace schemaregistry::serdes;
+
+/**
+ * Validation-rule executor backed by CEL. The rule expression is evaluated with
+ * `this` bound to the value being validated and `now` bound to the current
+ * time, and must resolve to a bool (false meaning the rule failed) or a string
+ * (non-empty meaning the rule failed, with that string as the message).
+ */
+class CelValidator : public ValidationRuleExecutor {
+  public:
+    CelValidator();
+    explicit CelValidator(std::shared_ptr<CelExecutor> executor);
+
+    std::string getType() const override;
+
+    ValidationRuleResult execute(const ValidationRule &rule,
+                                 const SerdeValue &value) override;
+
+    static void registerExecutor();
+
+  private:
+    std::shared_ptr<CelExecutor> executor_;
+};
+
+}  // namespace schemaregistry::rules::cel

--- a/include/schemaregistry/serdes/RuleRegistry.h
+++ b/include/schemaregistry/serdes/RuleRegistry.h
@@ -7,9 +7,9 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
-
 #include "schemaregistry/serdes/SerdeError.h"
 #include "schemaregistry/serdes/SerdeTypes.h"
+#include "schemaregistry/serdes/ValidationRule.h"
 
 namespace schemaregistry::serdes {
 
@@ -27,6 +27,7 @@ class RuleRegistry {
         rule_executors_;
     absl::flat_hash_map<std::string, std::shared_ptr<RuleAction>> rule_actions_;
     absl::flat_hash_map<std::string, RuleOverride> rule_overrides_;
+    std::shared_ptr<ValidationRuleExecutor> validation_executor_;
     mutable std::shared_mutex mutex_;
 
   public:
@@ -37,6 +38,12 @@ class RuleRegistry {
     void registerExecutor(std::shared_ptr<RuleExecutor> executor);
     std::shared_ptr<RuleExecutor> getExecutor(const std::string &type) const;
     std::vector<std::shared_ptr<RuleExecutor>> getExecutors() const;
+
+    // Validation rule executor management. Unlike rule executors there is a
+    // single validation executor, so registering replaces any previous one.
+    void registerValidationExecutor(
+        std::shared_ptr<ValidationRuleExecutor> executor);
+    std::shared_ptr<ValidationRuleExecutor> getValidationExecutor() const;
 
     // Rule action management
     void registerAction(std::shared_ptr<RuleAction> action);
@@ -82,6 +89,19 @@ std::shared_ptr<RuleExecutor> getRuleExecutor(const std::string &type);
  * Get all rule executors from global registry
  */
 std::vector<std::shared_ptr<RuleExecutor>> getRuleExecutors();
+
+/**
+ * Register the validation rule executor globally. There is a single validation
+ * executor, so this replaces any previously registered one.
+ */
+void registerValidationRuleExecutor(
+    std::shared_ptr<ValidationRuleExecutor> executor);
+
+/**
+ * Get the validation rule executor from the global registry, or nullptr when
+ * none has been registered
+ */
+std::shared_ptr<ValidationRuleExecutor> getValidationRuleExecutor();
 
 /**
  * Register a rule action globally

--- a/include/schemaregistry/serdes/Serde.h
+++ b/include/schemaregistry/serdes/Serde.h
@@ -257,6 +257,17 @@ class RuleContext {
                     const std::unordered_set<std::string> &tags);
     void exitField();
 
+    /**
+     * Set the type of the field currently being walked, replacing the one it was
+     * entered with. A walk records the type the schema declares for a field on
+     * entry and narrows it as it descends - a union field is entered as
+     * FieldType::Combined, and what an executor needs is the type of the branch
+     * the value holds. This has to go through the context: currentField()
+     * answers with a fresh FieldContext, because FieldContext cannot be copied,
+     * so setting the type on what it returns would be discarded.
+     */
+    void setCurrentFieldType(FieldType field_type);
+
     // Tag handling
     std::unordered_set<std::string> getTags(const std::string &full_name) const;
 

--- a/include/schemaregistry/serdes/Serde.h
+++ b/include/schemaregistry/serdes/Serde.h
@@ -369,6 +369,23 @@ class BaseSerializer {
     const Serde &getSerde() const { return serde_; }
     const SerializerConfig &getConfig() const { return config_; }
 
+    /**
+     * Whether inline validation rules should run at the given phase.
+     *
+     * Pass nullopt when there is a single validation point — a serialization
+     * path that applies no domain rules has nothing to run before or after, so
+     * any enabled mode validates there.
+     */
+    bool validationEnabled(std::optional<ValidationRulesExecution> phase) const;
+
+    /**
+     * The executor used to evaluate inline validation rules: the one configured
+     * on the serializer if set, otherwise the one registered on the
+     * serializer's rule registry, otherwise the globally registered one.
+     * Throws when none is available.
+     */
+    std::shared_ptr<ValidationRuleExecutor> validationExecutor() const;
+
     // Copy/move constructors and assignment operators - deleted due to Serde
     // containing non-copyable RuleRegistry
     BaseSerializer(const BaseSerializer &) = delete;

--- a/include/schemaregistry/serdes/SerdeConfig.h
+++ b/include/schemaregistry/serdes/SerdeConfig.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "schemaregistry/serdes/SerdeTypes.h"
+#include "schemaregistry/serdes/ValidationRule.h"
 
 namespace schemaregistry::rest {
 class ISchemaRegistryClient;
@@ -31,6 +32,21 @@ struct SerializerConfig {
     SubjectNameStrategyType subject_name_strategy_type;
     std::unordered_map<std::string, std::string> subject_name_strategy_config;
     SchemaIdSerializer schema_id_serializer;
+    /**
+     * When to evaluate the schema's inline validation rules. Disabled by
+     * default; set to BeforeDomainRules or AfterDomainRules to run them.
+     */
+    ValidationRulesExecution validation_rules_execution;
+    /**
+     * Stop at the first inline validation rule violation instead of collecting
+     * every violation in the message.
+     */
+    bool validation_rules_fail_fast;
+    /**
+     * Executor used to evaluate inline validation rules. When unset, the
+     * serializer's rule registry is consulted, then the global registry.
+     */
+    std::shared_ptr<ValidationRuleExecutor> validation_rule_executor;
 
     // Constructors
     SerializerConfig();

--- a/include/schemaregistry/serdes/SerdeTypes.h
+++ b/include/schemaregistry/serdes/SerdeTypes.h
@@ -34,6 +34,23 @@ namespace schemaregistry::serdes {
 enum class SerdeFormat { Avro, Json, Protobuf };
 
 /**
+ * Key identifying a schema in a parsed-schema cache.
+ *
+ * <p>The whole schema, not just its text. Parsing resolves the schema's
+ * references and inlines what they contain, so two schemas whose text is
+ * identical but whose references point at different subjects or versions parse
+ * to different things — and inline validation rules can come entirely from a
+ * referenced schema. Keying on the text alone would hand the second schema the
+ * first one's resolution.
+ */
+inline std::string schemaCacheKey(
+    const schemaregistry::rest::model::Schema &schema) {
+    nlohmann::json key_json;
+    to_json(key_json, schema);
+    return key_json.dump();
+}
+
+/**
  * Base interface for serialization values of different formats
  */
 class SerdeValue {

--- a/include/schemaregistry/serdes/ValidationRule.h
+++ b/include/schemaregistry/serdes/ValidationRule.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "schemaregistry/serdes/SerdeError.h"
+#include "schemaregistry/serdes/SerdeTypes.h"
+
+namespace schemaregistry::serdes {
+
+/**
+ * Determines when inline validation rules run, relative to domain rule
+ * transformations.
+ */
+enum class ValidationRulesExecution {
+    Disabled,
+    BeforeDomainRules,
+    AfterDomainRules
+};
+
+/**
+ * Parse a ValidationRulesExecution from its string form ("DISABLED",
+ * "BEFORE_DOMAIN_RULES", "AFTER_DOMAIN_RULES"). Returns nullopt when the string
+ * names no known mode.
+ */
+std::optional<ValidationRulesExecution> parseValidationRulesExecution(
+    const std::string &value);
+
+/**
+ * The schema property (Avro) / keyword (JSON Schema) that holds inline
+ * validation rules.
+ */
+constexpr const char *VALIDATION_RULES_PROP = "confluent:rules";
+
+/**
+ * An inline validation rule (a CHECK constraint) declared on a schema, either
+ * on a record/message/object or on one of its fields.
+ */
+struct ValidationRule {
+    std::string name;
+    std::string doc;
+    std::string expr;
+    std::string sql;
+};
+
+/**
+ * A single inline validation rule failure, located at field_path within the
+ * message that was validated.
+ */
+struct ValidationRuleError {
+    ValidationRule rule;
+    std::string field_path;
+    /**
+     * Optional dynamic error message returned by the rule itself — set when the
+     * rule expression returned a non-empty string explaining the failure (e.g.
+     * "x > 0 ? '' : 'x must be positive'"). Empty when the failure was a plain
+     * false or an evaluation error.
+     */
+    std::string message;
+    /** Executor failure text, when the rule could not be evaluated at all. */
+    std::string cause;
+
+    std::string toString() const;
+};
+
+/**
+ * Aggregates every inline validation rule failure found while walking a
+ * message.
+ */
+class ValidationRulesFailedError : public SerdeError {
+  public:
+    explicit ValidationRulesFailedError(
+        std::vector<ValidationRuleError> violations);
+
+    const std::vector<ValidationRuleError> &getViolations() const {
+        return violations_;
+    }
+
+  private:
+    std::vector<ValidationRuleError> violations_;
+};
+
+/**
+ * The outcome of evaluating a validation rule: either a bool (false meaning the
+ * rule failed) or a string (non-empty meaning the rule failed, with that string
+ * as the failure message).
+ */
+using ValidationRuleResult = std::variant<bool, std::string>;
+
+/**
+ * Evaluates a single inline validation rule against a value.
+ */
+class ValidationRuleExecutor {
+  public:
+    virtual ~ValidationRuleExecutor() = default;
+
+    /**
+     * Get the type identifier for this executor
+     */
+    virtual std::string getType() const = 0;
+
+    /**
+     * Evaluate the rule against value. Throws SerdeError when the rule cannot
+     * be compiled or evaluated, or when it resolves to something other than a
+     * bool or a string.
+     */
+    virtual ValidationRuleResult execute(const ValidationRule &rule,
+                                         const SerdeValue &value) = 0;
+};
+
+/**
+ * Parse a "confluent:rules" property value — a list of objects with
+ * name/doc/expr/sql keys. Anything that is not such a list yields no rules;
+ * malformed entries within the list are skipped.
+ */
+std::vector<ValidationRule> parseValidationRules(const nlohmann::json &prop);
+
+/**
+ * Evaluate one inline validation rule, appending a ValidationRuleError to
+ * violations when it fails. A rule that cannot be evaluated is itself recorded
+ * as a violation so the walk can continue.
+ *
+ * @return true when a violation was recorded
+ */
+bool evaluateValidationRule(ValidationRuleExecutor &executor,
+                            const ValidationRule &rule, const SerdeValue &value,
+                            const std::string &path,
+                            std::vector<ValidationRuleError> &violations);
+
+/**
+ * Throw a ValidationRulesFailedError listing every violation, or return
+ * normally when there are none.
+ */
+void raiseValidationViolations(std::vector<ValidationRuleError> violations);
+
+/**
+ * Append a field name to a dotted validation path.
+ */
+std::string appendValidationPath(const std::string &path,
+                                 const std::string &name);
+
+}  // namespace schemaregistry::serdes

--- a/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
@@ -109,6 +109,12 @@ class ProtobufSerializer {
 
     void validateSchema(const schemaregistry::rest::model::Schema &schema);
 
+    /**
+     * Evaluate the message's inline validation rules, throwing a single error
+     * listing every violation found.
+     */
+    void validateInlineRules(const google::protobuf::Message &message);
+
     std::string getRecordName(
         const std::optional<schemaregistry::rest::model::Schema> &schema);
 };
@@ -294,6 +300,11 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
             return utils::transformFields(rctx, descriptor, val);
         };
 
+        if (base_->validationEnabled(
+                ValidationRulesExecution::BeforeDomainRules)) {
+            validateInlineRules(message);
+        }
+
         google::protobuf::DynamicMessageFactory msg_factory;
         auto *dynamic_proto = msg_factory.GetPrototype(descriptor);
         auto dynamic_msg =
@@ -320,6 +331,11 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
         auto &transformed_msg =
             *proto_variant
                  .template get<std::unique_ptr<google::protobuf::Message>>();
+        if (base_->validationEnabled(
+                ValidationRulesExecution::AfterDomainRules)) {
+            validateInlineRules(transformed_msg);
+        }
+
         encoded_bytes.resize(
             static_cast<size_t>(transformed_msg.ByteSizeLong()));
         if (!transformed_msg.SerializeToArray(
@@ -327,6 +343,12 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
             throw ProtobufError("Failed to serialize protobuf message");
         }
     } else {
+        // No domain rules run on this path, so there is a single validation
+        // point regardless of the configured phase.
+        if (base_->validationEnabled(std::nullopt)) {
+            validateInlineRules(message);
+        }
+
         // Schema not present in registry – create & register or look it up.
         auto refs = resolveDependencies(ctx, descriptor->file());
 
@@ -376,6 +398,14 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
     // Final framing (schema id serialization).
     auto id_serializer = base_->getConfig().schema_id_serializer;
     return id_serializer(encoded_bytes, ctx, schema_id);
+}
+
+template <typename T>
+inline void ProtobufSerializer<T>::validateInlineRules(
+    const google::protobuf::Message &message) {
+    auto executor = base_->validationExecutor();
+    raiseValidationViolations(utils::validateMessage(
+        *executor, message, base_->getConfig().validation_rules_fail_fast));
 }
 
 template <typename T>

--- a/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
@@ -112,8 +112,14 @@ class ProtobufSerializer {
     /**
      * Evaluate the message's inline validation rules, throwing a single error
      * listing every violation found.
+     *
+     * When a schema was selected from the registry, its descriptor is the one
+     * carrying the rules — the caller's compiled-in descriptor may predate them
+     * — so pass that schema's pool and the message is re-resolved there before
+     * being validated. Pass nullptr when no registry schema was selected.
      */
-    void validateInlineRules(const google::protobuf::Message &message);
+    void validateInlineRules(const google::protobuf::Message &message,
+                             const google::protobuf::DescriptorPool *pool);
 
     std::string getRecordName(
         const std::optional<schemaregistry::rest::model::Schema> &schema);
@@ -145,8 +151,7 @@ inline ProtobufSerializer<T>::ProtobufSerializer(
       serde_(std::make_unique<ProtobufSerde>()),
       reference_subject_name_strategy_(defaultReferenceSubjectNameStrategy),
       subject_name_strategy_(configureSubjectNameStrategy(
-          config.subject_name_strategy_type,
-          base_->getSerde().getClient(),
+          config.subject_name_strategy_type, base_->getSerde().getClient(),
           config.subject_name_strategy_config,
           [this](const std::optional<schemaregistry::rest::model::Schema> &s) {
               return getRecordName(s);
@@ -180,8 +185,7 @@ inline ProtobufSerializer<T>::ProtobufSerializer(
       serde_(std::make_unique<ProtobufSerde>()),
       reference_subject_name_strategy_(std::move(strategy)),
       subject_name_strategy_(configureSubjectNameStrategy(
-          config.subject_name_strategy_type,
-          base_->getSerde().getClient(),
+          config.subject_name_strategy_type, base_->getSerde().getClient(),
           config.subject_name_strategy_config,
           [this](const std::optional<schemaregistry::rest::model::Schema> &s) {
               return getRecordName(s);
@@ -266,7 +270,8 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
     auto subject_opt =
         subject_name_strategy_(ctx.topic, ctx.serde_type, schema_);
     if (!subject_opt.has_value()) {
-        throw SerializationError("Could not determine subject for serialization");
+        throw SerializationError(
+            "Could not determine subject for serialization");
     }
     const std::string &subject = subject_opt.value();
 
@@ -302,7 +307,7 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
 
         if (base_->validationEnabled(
                 ValidationRulesExecution::BeforeDomainRules)) {
-            validateInlineRules(message);
+            validateInlineRules(message, pool);
         }
 
         google::protobuf::DynamicMessageFactory msg_factory;
@@ -333,7 +338,7 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
                  .template get<std::unique_ptr<google::protobuf::Message>>();
         if (base_->validationEnabled(
                 ValidationRulesExecution::AfterDomainRules)) {
-            validateInlineRules(transformed_msg);
+            validateInlineRules(transformed_msg, pool);
         }
 
         encoded_bytes.resize(
@@ -344,9 +349,10 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
         }
     } else {
         // No domain rules run on this path, so there is a single validation
-        // point regardless of the configured phase.
+        // point regardless of the configured phase, and no registry schema
+        // whose descriptor could carry the rules instead.
         if (base_->validationEnabled(std::nullopt)) {
-            validateInlineRules(message);
+            validateInlineRules(message, nullptr);
         }
 
         // Schema not present in registry – create & register or look it up.
@@ -402,10 +408,39 @@ ProtobufSerializer<T>::serializeWithMessageDescriptor(
 
 template <typename T>
 inline void ProtobufSerializer<T>::validateInlineRules(
-    const google::protobuf::Message &message) {
+    const google::protobuf::Message &message,
+    const google::protobuf::DescriptorPool *pool) {
     auto executor = base_->validationExecutor();
-    raiseValidationViolations(utils::validateMessage(
-        *executor, message, base_->getConfig().validation_rules_fail_fast));
+    bool fail_fast = base_->getConfig().validation_rules_fail_fast;
+
+    const google::protobuf::Descriptor *schema_descriptor = nullptr;
+    if (pool != nullptr) {
+        schema_descriptor =
+            pool->FindMessageTypeByName(message.GetDescriptor()->full_name());
+    }
+    if (schema_descriptor == nullptr ||
+        schema_descriptor == message.GetDescriptor()) {
+        raiseValidationViolations(
+            utils::validateMessage(*executor, message, fail_fast));
+        return;
+    }
+
+    // Re-resolve the message against the selected schema's descriptor. The two
+    // descriptors live in different pools, so round-trip through the wire
+    // format rather than CopyFrom.
+    google::protobuf::DynamicMessageFactory factory;
+    auto schema_msg = std::unique_ptr<google::protobuf::Message>(
+        factory.GetPrototype(schema_descriptor)->New());
+    std::string bytes;
+    if (!message.SerializeToString(&bytes) ||
+        !schema_msg->ParseFromString(bytes)) {
+        // Fall back to the caller's descriptor rather than skipping validation.
+        raiseValidationViolations(
+            utils::validateMessage(*executor, message, fail_fast));
+        return;
+    }
+    raiseValidationViolations(
+        utils::validateMessage(*executor, *schema_msg, fail_fast));
 }
 
 template <typename T>

--- a/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufSerializer.h
@@ -413,34 +413,17 @@ inline void ProtobufSerializer<T>::validateInlineRules(
     auto executor = base_->validationExecutor();
     bool fail_fast = base_->getConfig().validation_rules_fail_fast;
 
+    // The rules come from the selected schema's descriptor, which may declare
+    // fields - or name them - differently from the caller's generated type. The
+    // walk pairs the two by number and re-reads the message through the schema
+    // only when they present values differently; both live in validateMessage.
     const google::protobuf::Descriptor *schema_descriptor = nullptr;
     if (pool != nullptr) {
         schema_descriptor =
             pool->FindMessageTypeByName(message.GetDescriptor()->full_name());
     }
-    if (schema_descriptor == nullptr ||
-        schema_descriptor == message.GetDescriptor()) {
-        raiseValidationViolations(
-            utils::validateMessage(*executor, message, fail_fast));
-        return;
-    }
-
-    // Re-resolve the message against the selected schema's descriptor. The two
-    // descriptors live in different pools, so round-trip through the wire
-    // format rather than CopyFrom.
-    google::protobuf::DynamicMessageFactory factory;
-    auto schema_msg = std::unique_ptr<google::protobuf::Message>(
-        factory.GetPrototype(schema_descriptor)->New());
-    std::string bytes;
-    if (!message.SerializeToString(&bytes) ||
-        !schema_msg->ParseFromString(bytes)) {
-        // Fall back to the caller's descriptor rather than skipping validation.
-        raiseValidationViolations(
-            utils::validateMessage(*executor, message, fail_fast));
-        return;
-    }
     raiseValidationViolations(
-        utils::validateMessage(*executor, *schema_msg, fail_fast));
+        utils::validateMessage(*executor, message, schema_descriptor, fail_fast));
 }
 
 template <typename T>

--- a/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
@@ -21,6 +21,7 @@
 #include "schemaregistry/serdes/Serde.h"
 #include "schemaregistry/serdes/SerdeError.h"
 #include "schemaregistry/serdes/SerdeTypes.h"
+#include "schemaregistry/serdes/ValidationRule.h"
 #include "schemaregistry/serdes/protobuf/ProtobufTypes.h"
 
 namespace schemaregistry::serdes::protobuf::utils {
@@ -102,6 +103,30 @@ FieldType getFieldType(const google::protobuf::FieldDescriptor *field_desc);
  */
 std::unordered_set<std::string> getInlineTags(
     const google::protobuf::FieldDescriptor *field_desc);
+
+/**
+ * Walk message against its descriptor, evaluating every inline validation rule
+ * (confluent.Meta rules) encountered and collecting all failures. Read-only —
+ * the message is not modified.
+ *
+ * Two kinds of rules are evaluated:
+ *   - Message-level (rules on confluent.message_meta) — `this` is the message.
+ *   - Field-level (rules on confluent.field_meta) — `this` is the field value.
+ *     Honors the skip-on-null contract: a field with explicit presence that is
+ *     unset does not have its rules invoked.
+ *
+ * Failures carry their dotted-path location (e.g. addr.zip, tags[3],
+ * scores["foo"]). The walk continues after each failure so callers see the full
+ * set rather than only the first, unless fail_fast is set.
+ *
+ * @param executor Executor used to evaluate each rule
+ * @param message Protobuf message to validate
+ * @param fail_fast Stop at the first violation
+ * @return Every violation found, in walk order
+ */
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const google::protobuf::Message &message,
+    bool fail_fast);
 
 /**
  * Protobuf Message to JSON conversion

--- a/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
@@ -16,6 +16,7 @@
 #include <variant>
 #include <vector>
 
+#include "confluent/meta.pb.h"
 #include "schemaregistry/rest/ISchemaRegistryClient.h"
 #include "schemaregistry/rest/model/Schema.h"
 #include "schemaregistry/serdes/Serde.h"
@@ -102,6 +103,22 @@ FieldType getFieldType(const google::protobuf::FieldDescriptor *field_desc);
  * Extract inline tags from field options (confluent.field_meta)
  */
 std::unordered_set<std::string> getInlineTags(
+    const google::protobuf::FieldDescriptor *field_desc);
+
+/**
+ * The confluent.Meta carried by a message's or field's options, or nullopt if there
+ * is none.
+ *
+ * Reads the resolved extension when the pool that built the descriptor knew about
+ * confluent/meta.proto, and otherwise recovers it from the options' unknown fields:
+ * an options extension is only resolved if the extension was registered when the
+ * descriptor was built, which is not guaranteed for a descriptor from a pool built
+ * at runtime or for one registered by a different copy of the protobuf runtime.
+ * Falling back keeps rules and tags from silently disappearing in those setups.
+ */
+std::optional<confluent::Meta> getMessageMeta(
+    const google::protobuf::Descriptor *message_desc);
+std::optional<confluent::Meta> getFieldMeta(
     const google::protobuf::FieldDescriptor *field_desc);
 
 /**

--- a/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
@@ -128,7 +128,9 @@ std::optional<confluent::Meta> getFieldMeta(
  *
  * Two kinds of rules are evaluated:
  *   - Message-level (rules on confluent.message_meta) — `this` is the message.
- *   - Field-level (rules on confluent.field_meta) — `this` is the field value.
+ *   - Field-level (rules on confluent.field_meta) — `this` is the field value. A
+ *     repeated or map field binds the whole collection, once, so a rule about the
+ *     elements is written as a comprehension over them.
  *     Honors the skip-on-null contract: a field with explicit presence that is
  *     unset does not have its rules invoked.
  *

--- a/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
+++ b/include/schemaregistry/serdes/protobuf/ProtobufUtils.h
@@ -138,14 +138,23 @@ std::optional<confluent::Meta> getFieldMeta(
  * scores["foo"]). The walk continues after each failure so callers see the full
  * set rather than only the first, unless fail_fast is set.
  *
+ * The walk is driven by `message` - it decides which fields exist, which are
+ * absent, and what the values are - while `schema_descriptor` supplies the rules
+ * and the names a rule refers to, paired to the message's fields by number. Where
+ * the two present values differently, the message is re-read through the schema so
+ * that a rule binding `this` sees it in the schema's terms; that decision is made
+ * once per descriptor pair rather than per record.
+ *
  * @param executor Executor used to evaluate each rule
  * @param message Protobuf message to validate
+ * @param schema_descriptor The registered schema's descriptor for the message's
+ *     type, or null to read the rules from the message's own descriptor
  * @param fail_fast Stop at the first violation
  * @return Every violation found, in walk order
  */
 std::vector<ValidationRuleError> validateMessage(
     ValidationRuleExecutor &executor, const google::protobuf::Message &message,
-    bool fail_fast);
+    const google::protobuf::Descriptor *schema_descriptor, bool fail_fast);
 
 /**
  * Protobuf Message to JSON conversion

--- a/proto/confluent/meta.proto
+++ b/proto/confluent/meta.proto
@@ -7,6 +7,14 @@ message Meta {
   string doc = 1;
   map<string, string> params = 2;
   repeated string tags = 3;
+  repeated Rule rules = 4;
+}
+
+message Rule {
+  string name = 1;
+  string doc = 2;
+  string expr = 3;
+  string sql = 4;
 }
 
 extend google.protobuf.FileOptions {

--- a/src/internal/schemaregistry/rules/cel/CelExecutorImpl.h
+++ b/src/internal/schemaregistry/rules/cel/CelExecutorImpl.h
@@ -37,6 +37,15 @@ class CelExecutor::Impl {
                                   google::api::expr::runtime::CelValue> &args,
         google::protobuf::Arena *arena);
 
+    // Compile (with caching) and evaluate an expression against the given
+    // bindings. Carries no rule context, so it also serves the validation-rule
+    // path, which has no RuleContext of its own.
+    std::unique_ptr<google::api::expr::runtime::CelValue> evaluate(
+        const std::string &expr,
+        const absl::flat_hash_map<std::string,
+                                  google::api::expr::runtime::CelValue> &args,
+        google::protobuf::Arena *arena);
+
     absl::StatusOr<std::shared_ptr<google::api::expr::runtime::CelExpression>>
     getOrCompileExpression(const std::string &expr);
 

--- a/src/internal/schemaregistry/rules/cel/CelRules.h
+++ b/src/internal/schemaregistry/rules/cel/CelRules.h
@@ -2,6 +2,7 @@
 
 #include "schemaregistry/rules/cel/CelExecutor.h"
 #include "schemaregistry/rules/cel/CelFieldExecutor.h"
+#include "schemaregistry/rules/cel/CelValidator.h"
 
 namespace schemaregistry::rules::cel {
 
@@ -12,7 +13,8 @@ namespace schemaregistry::rules::cel {
 namespace registration {
 
 /**
- * Register all CEL rule executors (both CelExecutor and CelFieldExecutor)
+ * Register all CEL rule executors (CelExecutor, CelFieldExecutor and the
+ * CelValidator used for inline validation rules)
  * Call this function during application initialization to make CEL
  * rules available for use.
  */
@@ -27,6 +29,11 @@ void registerCelExecutor();
  * Register only the CEL field executor (for field-level transformations)
  */
 void registerCelFieldExecutor();
+
+/**
+ * Register only the CEL validator (for inline validation rules)
+ */
+void registerCelValidator();
 
 }  // namespace registration
 

--- a/src/internal/schemaregistry/serdes/avro/AvroTypes.h
+++ b/src/internal/schemaregistry/serdes/avro/AvroTypes.h
@@ -41,6 +41,22 @@ class AvroSerde {
         std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client);
 
     /**
+     * The schema JSON of the schema and of every schema it references, parsed
+     * once and cached. Inline validation reads rules from the schema JSON,
+     * because the Avro parser drops custom attributes, and it needs the
+     * referenced schemas so that a field naming a record from another subject
+     * resolves instead of being skipped.
+     * @param schema Schema to parse
+     * @param client Client for resolving references
+     * @return The schema JSON and the referenced schemas' JSON
+     */
+    std::shared_ptr<
+        const std::pair<nlohmann::json, std::vector<nlohmann::json>>>
+    getSchemaJsons(
+        const schemaregistry::rest::model::Schema &schema,
+        std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client);
+
+    /**
      * Clear all cached schemas
      */
     void clear();
@@ -50,6 +66,13 @@ class AvroSerde {
     std::unordered_map<std::string, std::pair<::avro::ValidSchema,
                                               std::vector<::avro::ValidSchema>>>
         parsed_schemas_;
+
+    // Cache for schema JSON: schema string -> (schema, referenced schemas)
+    std::unordered_map<
+        std::string,
+        std::shared_ptr<const std::pair<nlohmann::json,
+                                        std::vector<nlohmann::json>>>>
+        schema_jsons_;
 
     /**
      * Resolve schema references recursively

--- a/src/internal/schemaregistry/serdes/avro/AvroTypes.h
+++ b/src/internal/schemaregistry/serdes/avro/AvroTypes.h
@@ -67,7 +67,8 @@ class AvroSerde {
                                               std::vector<::avro::ValidSchema>>>
         parsed_schemas_;
 
-    // Cache for schema JSON: schema string -> (schema, referenced schemas)
+    // Keyed by schemaCacheKey(), like parsed_schemas_ above: the referenced
+    // schemas are part of what a lookup resolves to.
     std::unordered_map<
         std::string,
         std::shared_ptr<const std::pair<nlohmann::json,

--- a/src/internal/schemaregistry/serdes/avro/AvroUtils.h
+++ b/src/internal/schemaregistry/serdes/avro/AvroUtils.h
@@ -185,12 +185,16 @@ void getInlineTagsRecursively(
  * @param executor Executor used to evaluate each rule
  * @param schema Raw schema JSON — the Avro parser drops custom attributes, so
  * the rules must be read from the original schema text
+ * @param named_schemas Raw JSON of the referenced schemas, so that a field
+ * whose type names a record defined in another subject resolves to its
+ * definition instead of being skipped
  * @param datum Avro datum to validate
  * @param fail_fast Stop at the first violation
  * @return Every violation found, in walk order
  */
 std::vector<ValidationRuleError> validateMessage(
     ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const std::vector<nlohmann::json> &named_schemas,
     const ::avro::GenericDatum &datum, bool fail_fast);
 
 /**

--- a/src/internal/schemaregistry/serdes/avro/AvroUtils.h
+++ b/src/internal/schemaregistry/serdes/avro/AvroUtils.h
@@ -21,6 +21,7 @@
 #include "schemaregistry/rest/model/Schema.h"
 #include "schemaregistry/serdes/SerdeError.h"
 #include "schemaregistry/serdes/SerdeTypes.h"
+#include "schemaregistry/serdes/ValidationRule.h"
 #include "schemaregistry/serdes/avro/AvroTypes.h"
 
 namespace schemaregistry::serdes::avro {
@@ -164,6 +165,33 @@ void getInlineTagsRecursively(
     const std::string &ns, const std::string &name,
     const nlohmann::json &schema,
     std::unordered_map<std::string, std::unordered_set<std::string>> &tags);
+
+/**
+ * Walk datum against schema, evaluating every inline "confluent:rules" CHECK
+ * constraint encountered and collecting all failures. Read-only — the datum is
+ * not modified.
+ *
+ * Two kinds of rules are evaluated:
+ *   - Record-level ("confluent:rules" on a record schema) — `this` is the
+ *     record.
+ *   - Field-level ("confluent:rules" on a record's field) — `this` is the field
+ *     value. Honors the skip-on-null contract: a null field value does not have
+ *     its rules invoked.
+ *
+ * Failures carry their dotted-path location (e.g. addr.zip, tags[3],
+ * scores["foo"]). The walk continues after each failure so callers see the full
+ * set rather than only the first, unless fail_fast is set.
+ *
+ * @param executor Executor used to evaluate each rule
+ * @param schema Raw schema JSON — the Avro parser drops custom attributes, so
+ * the rules must be read from the original schema text
+ * @param datum Avro datum to validate
+ * @param fail_fast Stop at the first violation
+ * @return Every violation found, in walk order
+ */
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const ::avro::GenericDatum &datum, bool fail_fast);
 
 /**
  * Compile a JSON schema string to an Avro ValidSchema, removing confluent:tags

--- a/src/internal/schemaregistry/serdes/json/JsonTypes.h
+++ b/src/internal/schemaregistry/serdes/json/JsonTypes.h
@@ -46,13 +46,12 @@ class JsonSerde {
     void clear();
 
   private:
-    // Cache for parsed schemas: Schema -> json_schema
+    // Both caches are keyed by schemaCacheKey(), not by schema text: see there.
     std::unordered_map<
         std::string,
         std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>>>
         parsed_schemas_cache_;
 
-    // Cache for raw schema JSON: schema string -> parsed json
     std::unordered_map<std::string, std::shared_ptr<const nlohmann::json>>
         schema_json_cache_;
 

--- a/src/internal/schemaregistry/serdes/json/JsonTypes.h
+++ b/src/internal/schemaregistry/serdes/json/JsonTypes.h
@@ -31,6 +31,17 @@ class JsonSerde {
         const schemaregistry::rest::model::Schema &schema,
         std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client);
 
+    /**
+     * The schema's JSON with its references resolved and inlined, parsed once
+     * and cached. Inline validation walks the schema JSON rather than the
+     * compiled schema, and needs references flattened so that rules declared in
+     * a referenced schema are reachable; without that they would be silently
+     * skipped.
+     */
+    std::shared_ptr<const nlohmann::json> getSchemaJson(
+        const schemaregistry::rest::model::Schema &schema,
+        std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client);
+
     // Clear caches
     void clear();
 
@@ -40,6 +51,10 @@ class JsonSerde {
         std::string,
         std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>>>
         parsed_schemas_cache_;
+
+    // Cache for raw schema JSON: schema string -> parsed json
+    std::unordered_map<std::string, std::shared_ptr<const nlohmann::json>>
+        schema_json_cache_;
 
     mutable std::mutex cache_mutex_;
 

--- a/src/internal/schemaregistry/serdes/json/JsonUtils.h
+++ b/src/internal/schemaregistry/serdes/json/JsonUtils.h
@@ -130,6 +130,32 @@ std::unordered_set<std::string> getConfluentTags(const jsoncons::ojson &schema);
 }  // namespace schema_navigation
 
 /**
+ * Walk value against schema, evaluating every inline "confluent:rules" CHECK
+ * constraint encountered and collecting all failures. Read-only — the value is
+ * not modified.
+ *
+ * Two kinds of rules are evaluated:
+ *   - Object-level ("confluent:rules" on an object schema) — `this` is the
+ *     object.
+ *   - Property-level ("confluent:rules" on a property schema) — `this` is the
+ *     property value. Honors the skip-on-null contract: a property that is
+ *     absent or null does not have its rules invoked.
+ *
+ * Failures carry their location rooted at "$" to match the JVM client (e.g.
+ * $.addr.zip, $.tags[3]). The walk continues after each failure so callers see
+ * the full set rather than only the first, unless fail_fast is set.
+ *
+ * @param executor Executor used to evaluate each rule
+ * @param schema Raw schema JSON, also used as the base for local "$ref"
+ * @param value JSON value to validate
+ * @param fail_fast Stop at the first violation
+ * @return Every violation found, in walk order
+ */
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const nlohmann::json &value, bool fail_fast);
+
+/**
  * JSON validation utilities
  */
 namespace validation_utils {

--- a/src/rules/cel/CelExecutor.cpp
+++ b/src/rules/cel/CelExecutor.cpp
@@ -10,6 +10,8 @@
 #include "eval/public/containers/container_backed_map_impl.h"
 #include "eval/public/string_extension_func_registrar.h"
 #include "eval/public/structs/cel_proto_wrapper.h"
+#include "extensions/math_ext.h"
+#include "extensions/math_ext_macros.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/message.h"
 #include "nlohmann/json.hpp"
@@ -60,6 +62,12 @@ absl::StatusOr<
 CelExecutor::Impl::newRuleBuilder(google::protobuf::Arena *arena) {
     google::api::expr::runtime::InterpreterOptions options;
     options.enable_qualified_type_identifiers = true;
+    // The math extension's functions are registered under namespaced names
+    // (math.abs, math.bitAnd). Without this the parser's receiver-style call -
+    // `abs` with the target `math` - is never folded into that name, and every
+    // one of them fails to plan. cel-cpp's own math extension test sets it for
+    // the same reason.
+    options.enable_qualified_identifier_rewrites = true;
     options.enable_timestamp_duration_overflow_errors = true;
     options.enable_heterogeneous_equality = true;
     options.enable_empty_wrapper_null_unboxing = true;
@@ -77,6 +85,11 @@ CelExecutor::Impl::newRuleBuilder(google::protobuf::Arena *arena) {
     register_status =
         google::api::expr::runtime::RegisterStringExtensionFunctions(
             builder->GetRegistry());
+    if (!register_status.ok()) {
+        return register_status;
+    }
+    register_status = ::cel::extensions::RegisterMathExtensionFunctions(
+        builder->GetRegistry(), options);
     if (!register_status.ok()) {
         return register_status;
     }
@@ -205,7 +218,19 @@ CelExecutor::Impl::getOrCompileExpression(const std::string &expr) {
         return absl::FailedPreconditionError("CEL runtime not initialized");
     }
 
-    auto pexpr_or = google::api::expr::parser::Parse(expr);
+    // math.greatest and math.least are macros rather than registry functions -
+    // they take a variable number of arguments - so the parser has to know them
+    // as well. Parsing with an explicit macro list replaces the default set, so
+    // the standard macros (has, all, exists, exists_one, map, filter) are
+    // carried along with them.
+    static const std::vector<::cel::Macro> *kMacros = [] {
+        auto *macros = new std::vector<::cel::Macro>(::cel::Macro::AllMacros());
+        auto math = ::cel::extensions::math_macros();
+        macros->insert(macros->end(), math.begin(), math.end());
+        return macros;
+    }();
+
+    auto pexpr_or = google::api::expr::parser::ParseWithMacros(expr, *kMacros);
     if (!pexpr_or.ok()) {
         return pexpr_or.status();
     }

--- a/src/rules/cel/CelExecutor.cpp
+++ b/src/rules/cel/CelExecutor.cpp
@@ -153,6 +153,15 @@ CelExecutor::Impl::executeRule(
     const absl::flat_hash_map<std::string, google::api::expr::runtime::CelValue>
         &args,
     google::protobuf::Arena *arena) {
+    return evaluate(expr, args, arena);
+}
+
+std::unique_ptr<google::api::expr::runtime::CelValue>
+CelExecutor::Impl::evaluate(
+    const std::string &expr,
+    const absl::flat_hash_map<std::string, google::api::expr::runtime::CelValue>
+        &args,
+    google::protobuf::Arena *arena) {
     // Get or compile the expression (with caching)
     auto parsed_expr_status = getOrCompileExpression(expr);
     if (!parsed_expr_status.ok()) {

--- a/src/rules/cel/CelExecutor.cpp
+++ b/src/rules/cel/CelExecutor.cpp
@@ -61,6 +61,7 @@ CelExecutor::Impl::newRuleBuilder(google::protobuf::Arena *arena) {
     google::api::expr::runtime::InterpreterOptions options;
     options.enable_qualified_type_identifiers = true;
     options.enable_timestamp_duration_overflow_errors = true;
+    options.enable_heterogeneous_equality = true;
     options.enable_empty_wrapper_null_unboxing = true;
     options.enable_regex_precompilation = true;
     options.constant_folding = true;

--- a/src/rules/cel/CelRules.cpp
+++ b/src/rules/cel/CelRules.cpp
@@ -5,10 +5,13 @@ namespace schemaregistry::rules::cel::registration {
 void registerAllCelExecutors() {
     registerCelExecutor();
     registerCelFieldExecutor();
+    registerCelValidator();
 }
 
 void registerCelExecutor() { CelExecutor::registerExecutor(); }
 
 void registerCelFieldExecutor() { CelFieldExecutor::registerExecutor(); }
+
+void registerCelValidator() { CelValidator::registerExecutor(); }
 
 }  // namespace schemaregistry::rules::cel::registration

--- a/src/rules/cel/CelUtils.cpp
+++ b/src/rules/cel/CelUtils.cpp
@@ -550,7 +550,12 @@ google::api::expr::runtime::CelValue fromProtobufValue(
                 google::api::expr::runtime::CelValue cel_value =
                     google::api::expr::runtime::CelValue::CreateNull();
 
-                if (field->is_repeated()) {
+                if (field->is_map()) {
+                    // Maps are repeated in the reflection API, so they must be
+                    // handled before the repeated branch or they bind as a list
+                    // of entries.
+                    cel_value = convertProtobufMapToCel(*msg, field, arena);
+                } else if (field->is_repeated()) {
                     std::vector<google::api::expr::runtime::CelValue> vec;
                     int field_size = reflection->FieldSize(*msg, field);
 
@@ -665,13 +670,15 @@ google::api::expr::runtime::CelValue convertProtobufFieldToCel(
             return google::api::expr::runtime::CelValue::CreateInt64(value);
         }
 
+        // As in fromProtobufValue: unsigned values keep CEL's unsigned type, so
+        // that a uint64 above int64 max is not seen as negative.
         case google::protobuf::FieldDescriptor::CPPTYPE_UINT32: {
             uint32_t value =
                 (index >= 0)
                     ? reflection->GetRepeatedUInt32(message, field, index)
                     : reflection->GetUInt32(message, field);
-            return google::api::expr::runtime::CelValue::CreateInt64(
-                static_cast<int64_t>(value));
+            return google::api::expr::runtime::CelValue::CreateUint64(
+                static_cast<uint64_t>(value));
         }
 
         case google::protobuf::FieldDescriptor::CPPTYPE_UINT64: {
@@ -679,8 +686,7 @@ google::api::expr::runtime::CelValue convertProtobufFieldToCel(
                 (index >= 0)
                     ? reflection->GetRepeatedUInt64(message, field, index)
                     : reflection->GetUInt64(message, field);
-            return google::api::expr::runtime::CelValue::CreateInt64(
-                static_cast<int64_t>(value));
+            return google::api::expr::runtime::CelValue::CreateUint64(value);
         }
 
         case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT: {
@@ -731,7 +737,10 @@ google::api::expr::runtime::CelValue convertProtobufFieldToCel(
                     : reflection->GetMessage(message, field);
 
             if (field->is_map()) {
-                return convertProtobufMapToCel(nested_message, field, arena);
+                // Reached only when a caller asks for a single entry; the whole
+                // map is built by the message binding below, which passes the
+                // containing message.
+                return convertProtobufMapToCel(message, field, arena);
             } else {
                 auto message_copy = std::unique_ptr<google::protobuf::Message>(
                     nested_message.New());
@@ -748,34 +757,41 @@ google::api::expr::runtime::CelValue convertProtobufFieldToCel(
 }
 
 google::api::expr::runtime::CelValue convertProtobufMapToCel(
-    const google::protobuf::Message &map_entry,
-    const google::protobuf::FieldDescriptor * /*map_field*/,
+    const google::protobuf::Message &message,
+    const google::protobuf::FieldDescriptor *map_field,
     google::protobuf::Arena *arena) {
     auto *map_impl = google::protobuf::Arena::Create<
         google::api::expr::runtime::CelMapBuilder>(arena);
 
-    const auto *descriptor = map_entry.GetDescriptor();
-    const auto *reflection = map_entry.GetReflection();
-
-    if (!descriptor || !reflection) {
+    const auto *reflection = message.GetReflection();
+    if (map_field == nullptr || reflection == nullptr ||
+        !map_field->is_map()) {
         return google::api::expr::runtime::CelValue::CreateMap(map_impl);
     }
 
-    const auto *key_field = descriptor->field(0);
-    const auto *value_field = descriptor->field(1);
-
-    if (!key_field || !value_field) {
+    // A protobuf map is a repeated field of two-field entry messages. Aggregate
+    // every entry into a single CEL map, so that `this.scores["foo"]` indexes a
+    // map rather than a list of one-entry maps.
+    const auto *entry_descriptor = map_field->message_type();
+    const auto *key_field = entry_descriptor->map_key();
+    const auto *value_field = entry_descriptor->map_value();
+    if (key_field == nullptr || value_field == nullptr) {
         return google::api::expr::runtime::CelValue::CreateMap(map_impl);
     }
 
-    auto cel_key =
-        convertProtobufFieldToCel(map_entry, key_field, reflection, arena, -1);
-    auto cel_value = convertProtobufFieldToCel(map_entry, value_field,
-                                               reflection, arena, -1);
-
-    if (!cel_key.IsError() && !cel_value.IsError()) {
-        auto status = map_impl->Add(cel_key, cel_value);
-        if (!status.ok()) {
+    int count = reflection->FieldSize(message, map_field);
+    for (int i = 0; i < count; ++i) {
+        const auto &entry =
+            reflection->GetRepeatedMessage(message, map_field, i);
+        const auto *entry_reflection = entry.GetReflection();
+        auto cel_key = convertProtobufFieldToCel(entry, key_field,
+                                                 entry_reflection, arena, -1);
+        auto cel_value = convertProtobufFieldToCel(entry, value_field,
+                                                   entry_reflection, arena, -1);
+        if (!cel_key.IsError() && !cel_value.IsError()) {
+            auto status = map_impl->Add(cel_key, cel_value);
+            if (!status.ok()) {
+            }
         }
     }
 

--- a/src/rules/cel/CelUtils.cpp
+++ b/src/rules/cel/CelUtils.cpp
@@ -470,13 +470,16 @@ google::api::expr::runtime::CelValue fromProtobufValue(
             return google::api::expr::runtime::CelValue::CreateInt64(
                 variant.get<int64_t>());
 
+        // CEL has a distinct unsigned type; narrowing these to Int would wrap
+        // any u64 above int64 max to a negative number, so `this > 0` would
+        // reject valid values.
         case ProtobufVariant::ValueType::U32:
-            return google::api::expr::runtime::CelValue::CreateInt64(
-                static_cast<int64_t>(variant.get<uint32_t>()));
+            return google::api::expr::runtime::CelValue::CreateUint64(
+                static_cast<uint64_t>(variant.get<uint32_t>()));
 
         case ProtobufVariant::ValueType::U64:
-            return google::api::expr::runtime::CelValue::CreateInt64(
-                static_cast<int64_t>(variant.get<uint64_t>()));
+            return google::api::expr::runtime::CelValue::CreateUint64(
+                variant.get<uint64_t>());
 
         case ProtobufVariant::ValueType::F32:
             return google::api::expr::runtime::CelValue::CreateDouble(
@@ -524,12 +527,12 @@ google::api::expr::runtime::CelValue fromProtobufValue(
             auto *map_impl = google::protobuf::Arena::Create<
                 google::api::expr::runtime::CelMapBuilder>(arena);
 
-            // Walk the descriptor rather than only the populated fields: a proto3
-            // scalar sitting at its default is still set as far as the language is
-            // concerned, and omitting it makes an expression like `msg.count == 0`
-            // fail with "no such key". Fields with explicit presence (optional,
-            // oneof members, messages) are still omitted when unset, so that
-            // has(...) keeps working.
+            // Walk the descriptor rather than only the populated fields: a
+            // proto3 scalar sitting at its default is still set as far as the
+            // language is concerned, and omitting it makes an expression like
+            // `msg.count == 0` fail with "no such key". Fields with explicit
+            // presence (optional, oneof members, messages) are still omitted
+            // when unset, so that has(...) keeps working.
             for (int field_index = 0; field_index < descriptor->field_count();
                  ++field_index) {
                 const auto *field = descriptor->field(field_index);

--- a/src/rules/cel/CelUtils.cpp
+++ b/src/rules/cel/CelUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "eval/public/containers/container_backed_list_impl.h"
 #include "eval/public/containers/container_backed_map_impl.h"
+#include "eval/public/structs/cel_proto_wrapper.h"
 
 // Fix for Windows GetMessage macro conflict
 // On Windows, GetMessage is defined as a macro in winuser.h which conflicts
@@ -517,75 +518,24 @@ google::api::expr::runtime::CelValue fromProtobufValue(
                 return google::api::expr::runtime::CelValue::CreateNull();
             }
 
-            const auto *descriptor = msg->GetDescriptor();
-            if (!descriptor)
-                return google::api::expr::runtime::CelValue::CreateNull();
-            const auto *reflection = msg->GetReflection();
-            if (!reflection)
-                return google::api::expr::runtime::CelValue::CreateNull();
-
-            auto *map_impl = google::protobuf::Arena::Create<
-                google::api::expr::runtime::CelMapBuilder>(arena);
-
-            // Walk the descriptor rather than only the populated fields: a
-            // proto3 scalar sitting at its default is still set as far as the
-            // language is concerned, and omitting it makes an expression like
-            // `msg.count == 0` fail with "no such key". Fields with explicit
-            // presence (optional, oneof members, messages) are still omitted
-            // when unset, so that has(...) keeps working.
-            for (int field_index = 0; field_index < descriptor->field_count();
-                 ++field_index) {
-                const auto *field = descriptor->field(field_index);
-                if (field->has_presence() &&
-                    !reflection->HasField(*msg, field)) {
-                    continue;
-                }
-                auto *arena_field_name =
-                    google::protobuf::Arena::Create<std::string>(arena,
-                                                                 field->name());
-                auto cel_key =
-                    google::api::expr::runtime::CelValue::CreateString(
-                        arena_field_name);
-
-                google::api::expr::runtime::CelValue cel_value =
-                    google::api::expr::runtime::CelValue::CreateNull();
-
-                if (field->is_map()) {
-                    // Maps are repeated in the reflection API, so they must be
-                    // handled before the repeated branch or they bind as a list
-                    // of entries.
-                    cel_value = convertProtobufMapToCel(*msg, field, arena);
-                } else if (field->is_repeated()) {
-                    std::vector<google::api::expr::runtime::CelValue> vec;
-                    int field_size = reflection->FieldSize(*msg, field);
-
-                    for (int i = 0; i < field_size; ++i) {
-                        cel_value = convertProtobufFieldToCel(
-                            *msg, field, reflection, arena, i);
-                        if (!cel_value.IsError()) {
-                            vec.push_back(cel_value);
-                        }
-                    }
-
-                    auto *list_impl = google::protobuf::Arena::Create<
-                        google::api::expr::runtime::ContainerBackedListImpl>(
-                        arena, vec);
-                    cel_value =
-                        google::api::expr::runtime::CelValue::CreateList(
-                            list_impl);
-                } else {
-                    cel_value = convertProtobufFieldToCel(
-                        *msg, field, reflection, arena, -1);
-                }
-
-                if (!cel_value.IsError()) {
-                    auto status = map_impl->Add(cel_key, cel_value);
-                    if (!status.ok()) {
-                    }
-                }
-            }
-
-            return google::api::expr::runtime::CelValue::CreateMap(map_impl);
+            // Hand cel-cpp the message itself rather than a map of its fields.
+            // The engine then answers from the descriptor, which is what the other
+            // clients' engines do and what protovalidate-cc does:
+            //
+            //   - has() follows protobuf presence, so an unset field reads as unset
+            //     rather than as its default. A map cannot express that: the key has
+            //     to be there for `this.count == 0` to resolve, and its being there
+            //     is what has() reports.
+            //   - a well-known type becomes the value it wraps - a Timestamp a CEL
+            //     timestamp, a StringValue a string - which CreateMessage does by
+            //     downcasting. Built as a map it stayed a map of seconds and nanos.
+            //
+            // The copy is arena-allocated because the CelValue holds a bare pointer
+            // and has to stay valid for the whole evaluation, outliving this variant.
+            auto *owned = msg->New(arena);
+            owned->CopyFrom(*msg);
+            return google::api::expr::runtime::CelProtoWrapper::CreateMessage(
+                owned, arena);
         }
 
         case ProtobufVariant::ValueType::List: {

--- a/src/rules/cel/CelUtils.cpp
+++ b/src/rules/cel/CelUtils.cpp
@@ -524,10 +524,19 @@ google::api::expr::runtime::CelValue fromProtobufValue(
             auto *map_impl = google::protobuf::Arena::Create<
                 google::api::expr::runtime::CelMapBuilder>(arena);
 
-            std::vector<const google::protobuf::FieldDescriptor *> fields;
-            reflection->ListFields(*msg, &fields);
-
-            for (const auto *field : fields) {
+            // Walk the descriptor rather than only the populated fields: a proto3
+            // scalar sitting at its default is still set as far as the language is
+            // concerned, and omitting it makes an expression like `msg.count == 0`
+            // fail with "no such key". Fields with explicit presence (optional,
+            // oneof members, messages) are still omitted when unset, so that
+            // has(...) keeps working.
+            for (int field_index = 0; field_index < descriptor->field_count();
+                 ++field_index) {
+                const auto *field = descriptor->field(field_index);
+                if (field->has_presence() &&
+                    !reflection->HasField(*msg, field)) {
+                    continue;
+                }
                 auto *arena_field_name =
                     google::protobuf::Arena::Create<std::string>(arena,
                                                                  field->name());

--- a/src/rules/cel/CelUtils.cpp
+++ b/src/rules/cel/CelUtils.cpp
@@ -571,6 +571,15 @@ google::api::expr::runtime::CelValue fromProtobufValue(
                         } else if constexpr (std::is_same_v<T, bool>) {
                             cel_key = google::api::expr::runtime::CelValue::
                                 CreateBool(k);
+                        } else if constexpr (std::is_unsigned_v<T>) {
+                            // CEL has a distinct unsigned type, and a map key is
+                            // the one value whose type comes from the key field
+                            // rather than from the value itself. Narrowing an
+                            // unsigned key to int64 wraps anything above int64
+                            // max to a negative number, so a rule could neither
+                            // index by such a key nor compare it.
+                            cel_key = google::api::expr::runtime::CelValue::
+                                CreateUint64(static_cast<uint64_t>(k));
                         } else {
                             cel_key = google::api::expr::runtime::CelValue::
                                 CreateInt64(static_cast<int64_t>(k));

--- a/src/rules/cel/CelValidator.cpp
+++ b/src/rules/cel/CelValidator.cpp
@@ -1,0 +1,71 @@
+#include "schemaregistry/rules/cel/CelValidator.h"
+
+#include "absl/time/clock.h"
+#include "eval/public/cel_value.h"
+#include "google/protobuf/arena.h"
+#include "schemaregistry/rules/cel/CelExecutorImpl.h"
+#include "schemaregistry/serdes/RuleRegistry.h"
+#include "schemaregistry/serdes/SerdeError.h"
+
+namespace schemaregistry::rules::cel {
+
+namespace {
+
+std::string ruleName(const ValidationRule &rule) {
+    return rule.name.empty() ? "unnamed" : rule.name;
+}
+
+}  // namespace
+
+CelValidator::CelValidator() : executor_(std::make_shared<CelExecutor>()) {}
+
+CelValidator::CelValidator(std::shared_ptr<CelExecutor> executor)
+    : executor_(std::move(executor)) {}
+
+std::string CelValidator::getType() const { return "CEL"; }
+
+ValidationRuleResult CelValidator::execute(const ValidationRule &rule,
+                                           const SerdeValue &value) {
+    if (rule.expr.empty()) {
+        throw SerdeError("Validation rule '" + ruleName(rule) +
+                         "' has no expression");
+    }
+    if (!executor_) {
+        throw SerdeError("Validation rule '" + ruleName(rule) +
+                         "' has no CEL executor");
+    }
+
+    google::protobuf::Arena arena;
+    absl::flat_hash_map<std::string, google::api::expr::runtime::CelValue> args;
+    args.emplace("this", executor_->impl_->fromSerdeValue(value, &arena));
+    args.emplace("now", google::api::expr::runtime::CelValue::CreateTimestamp(
+                            absl::Now()));
+
+    auto result = executor_->impl_->evaluate(rule.expr, args, &arena);
+    if (!result) {
+        throw SerdeError("Validation rule '" + ruleName(rule) +
+                         "' produced no result");
+    }
+
+    if (result->IsError()) {
+        const auto *error = result->ErrorOrDie();
+        throw SerdeError(
+            "Validation rule '" + ruleName(rule) +
+            "' failed to evaluate: " + std::string(error->message()));
+    }
+    if (result->IsBool()) {
+        return result->BoolOrDie();
+    }
+    if (result->IsString()) {
+        return std::string(result->StringOrDie().value());
+    }
+    throw SerdeError("Validation rule '" + ruleName(rule) +
+                     "' must return bool or string");
+}
+
+void CelValidator::registerExecutor() {
+    global_registry::registerValidationRuleExecutor(
+        std::make_shared<CelValidator>());
+}
+
+}  // namespace schemaregistry::rules::cel

--- a/src/rules/cel/CelValidator.cpp
+++ b/src/rules/cel/CelValidator.cpp
@@ -9,6 +9,10 @@
 
 namespace schemaregistry::rules::cel {
 
+// Pulled in here rather than in the header, so that including CelValidator.h does not
+// leak the whole serdes namespace into the consumer's translation unit.
+using namespace schemaregistry::serdes;
+
 namespace {
 
 std::string ruleName(const ValidationRule &rule) {

--- a/src/serdes/RuleRegistry.cpp
+++ b/src/serdes/RuleRegistry.cpp
@@ -41,6 +41,22 @@ std::vector<std::shared_ptr<RuleExecutor>> RuleRegistry::getExecutors() const {
     return result;
 }
 
+void RuleRegistry::registerValidationExecutor(
+    std::shared_ptr<ValidationRuleExecutor> executor) {
+    if (!executor) {
+        throw std::invalid_argument("Cannot register null validation executor");
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    validation_executor_ = std::move(executor);
+}
+
+std::shared_ptr<ValidationRuleExecutor> RuleRegistry::getValidationExecutor()
+    const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return validation_executor_;
+}
+
 void RuleRegistry::registerAction(std::shared_ptr<RuleAction> action) {
     if (!action) {
         throw std::invalid_argument("Cannot register null action");
@@ -104,6 +120,7 @@ void RuleRegistry::clear() {
     rule_executors_.clear();
     rule_actions_.clear();
     rule_overrides_.clear();
+    validation_executor_.reset();
 }
 
 // Global registry implementation
@@ -125,6 +142,15 @@ std::shared_ptr<RuleExecutor> getRuleExecutor(const std::string &type) {
 
 std::vector<std::shared_ptr<RuleExecutor>> getRuleExecutors() {
     return getInstance().getExecutors();
+}
+
+void registerValidationRuleExecutor(
+    std::shared_ptr<ValidationRuleExecutor> executor) {
+    getInstance().registerValidationExecutor(std::move(executor));
+}
+
+std::shared_ptr<ValidationRuleExecutor> getValidationRuleExecutor() {
+    return getInstance().getValidationExecutor();
 }
 
 void registerRuleAction(std::shared_ptr<RuleAction> action) {

--- a/src/serdes/Serde.cpp
+++ b/src/serdes/Serde.cpp
@@ -976,6 +976,37 @@ bool Serde::hasRules(std::optional<RuleSet> rule_set, Phase phase,
 BaseSerializer::BaseSerializer(Serde serde, const SerializerConfig &config)
     : serde_(std::move(serde)), config_(config) {}
 
+bool BaseSerializer::validationEnabled(
+    std::optional<ValidationRulesExecution> phase) const {
+    if (!phase.has_value()) {
+        return config_.validation_rules_execution !=
+               ValidationRulesExecution::Disabled;
+    }
+    return config_.validation_rules_execution == phase.value();
+}
+
+std::shared_ptr<ValidationRuleExecutor> BaseSerializer::validationExecutor()
+    const {
+    if (config_.validation_rule_executor) {
+        return config_.validation_rule_executor;
+    }
+    auto registry = serde_.getRuleRegistry();
+    if (registry) {
+        auto executor = registry->getValidationExecutor();
+        if (executor) {
+            return executor;
+        }
+    }
+    auto executor = global_registry::getValidationRuleExecutor();
+    if (!executor) {
+        throw SerializationError(
+            "No validation rule executor registered; call "
+            "schemaregistry::rules::cel::registration::registerCelValidator() "
+            "or set validation_rule_executor on the serializer config");
+    }
+    return executor;
+}
+
 // BaseDeserializer implementation
 
 BaseDeserializer::BaseDeserializer(Serde serde,

--- a/src/serdes/Serde.cpp
+++ b/src/serdes/Serde.cpp
@@ -410,6 +410,13 @@ std::optional<FieldContext> RuleContext::currentField() const {
         back.getFieldType(), back.getTags());
 }
 
+void RuleContext::setCurrentFieldType(FieldType field_type) {
+    if (field_contexts_.empty()) {
+        return;
+    }
+    field_contexts_.back()->setFieldType(field_type);
+}
+
 void RuleContext::enterField(const SerdeValue &containing_message,
                              const std::string &full_name,
                              const std::string &name, FieldType field_type,

--- a/src/serdes/SerdeConfig.cpp
+++ b/src/serdes/SerdeConfig.cpp
@@ -16,7 +16,10 @@ SerializerConfig::SerializerConfig()
       rule_config({}),
       subject_name_strategy_type(SubjectNameStrategyType::Associated),
       subject_name_strategy_config({}),
-      schema_id_serializer(prefixSchemaIdSerializer) {}
+      schema_id_serializer(prefixSchemaIdSerializer),
+      validation_rules_execution(ValidationRulesExecution::Disabled),
+      validation_rules_fail_fast(false),
+      validation_rule_executor(nullptr) {}
 
 SerializerConfig::SerializerConfig(
     bool auto_register_schemas, std::optional<SchemaSelector> use_schema,
@@ -29,7 +32,10 @@ SerializerConfig::SerializerConfig(
       rule_config(rule_config),
       subject_name_strategy_type(SubjectNameStrategyType::Associated),
       subject_name_strategy_config({}),
-      schema_id_serializer(prefixSchemaIdSerializer) {}
+      schema_id_serializer(prefixSchemaIdSerializer),
+      validation_rules_execution(ValidationRulesExecution::Disabled),
+      validation_rules_fail_fast(false),
+      validation_rule_executor(nullptr) {}
 
 SerializerConfig SerializerConfig::createDefault() {
     return SerializerConfig();

--- a/src/serdes/ValidationRule.cpp
+++ b/src/serdes/ValidationRule.cpp
@@ -1,0 +1,127 @@
+#include "schemaregistry/serdes/ValidationRule.h"
+
+#include <sstream>
+
+namespace schemaregistry::serdes {
+
+std::optional<ValidationRulesExecution> parseValidationRulesExecution(
+    const std::string &value) {
+    if (value == "DISABLED") {
+        return ValidationRulesExecution::Disabled;
+    }
+    if (value == "BEFORE_DOMAIN_RULES") {
+        return ValidationRulesExecution::BeforeDomainRules;
+    }
+    if (value == "AFTER_DOMAIN_RULES") {
+        return ValidationRulesExecution::AfterDomainRules;
+    }
+    return std::nullopt;
+}
+
+std::string ValidationRuleError::toString() const {
+    std::ostringstream out;
+    out << (field_path.empty() ? "<root>" : field_path) << ": "
+        << (rule.name.empty() ? "unnamed" : rule.name) << ": ";
+    // Prefer the dynamic message returned by the rule itself; fall back to the
+    // rule's authored doc / SQL / CEL expression in that order.
+    if (!message.empty()) {
+        out << message;
+    } else if (!rule.doc.empty()) {
+        out << rule.doc;
+    } else if (!rule.sql.empty()) {
+        out << rule.sql;
+    } else {
+        out << rule.expr;
+    }
+    if (!cause.empty()) {
+        out << " (caused by: " << cause << ")";
+    }
+    return out.str();
+}
+
+namespace {
+
+std::string buildMessage(const std::vector<ValidationRuleError> &violations) {
+    if (violations.empty()) {
+        return "Validation rule failed (no detail)";
+    }
+    std::ostringstream out;
+    out << "Validation rule failed (" << violations.size()
+        << (violations.size() == 1 ? " violation):" : " violations):");
+    for (const auto &violation : violations) {
+        out << "\n  - " << violation.toString();
+    }
+    return out.str();
+}
+
+std::string stringProp(const nlohmann::json &entry, const std::string &key) {
+    auto it = entry.find(key);
+    if (it == entry.end() || !it->is_string()) {
+        return "";
+    }
+    return it->get<std::string>();
+}
+
+}  // namespace
+
+ValidationRulesFailedError::ValidationRulesFailedError(
+    std::vector<ValidationRuleError> violations)
+    : SerdeError(buildMessage(violations)),
+      violations_(std::move(violations)) {}
+
+std::vector<ValidationRule> parseValidationRules(const nlohmann::json &prop) {
+    std::vector<ValidationRule> rules;
+    if (!prop.is_array()) {
+        return rules;
+    }
+    for (const auto &entry : prop) {
+        if (!entry.is_object()) {
+            continue;
+        }
+        rules.push_back(ValidationRule{
+            stringProp(entry, "name"), stringProp(entry, "doc"),
+            stringProp(entry, "expr"), stringProp(entry, "sql")});
+    }
+    return rules;
+}
+
+bool evaluateValidationRule(ValidationRuleExecutor &executor,
+                            const ValidationRule &rule, const SerdeValue &value,
+                            const std::string &path,
+                            std::vector<ValidationRuleError> &violations) {
+    ValidationRuleResult result;
+    try {
+        result = executor.execute(rule, value);
+    } catch (const std::exception &e) {
+        violations.push_back(
+            ValidationRuleError{rule, path, "", std::string(e.what())});
+        return true;
+    }
+    if (std::holds_alternative<bool>(result)) {
+        if (!std::get<bool>(result)) {
+            violations.push_back(ValidationRuleError{rule, path, "", ""});
+            return true;
+        }
+        return false;
+    }
+    const std::string &message = std::get<std::string>(result);
+    if (!message.empty()) {
+        violations.push_back(ValidationRuleError{rule, path, message, ""});
+        return true;
+    }
+    return false;
+}
+
+void raiseValidationViolations(std::vector<ValidationRuleError> violations) {
+    if (violations.empty()) {
+        return;
+    }
+    throw ValidationRulesFailedError(std::move(violations));
+}
+
+std::string appendValidationPath(const std::string &path,
+                                 const std::string &name) {
+    return path.empty() ? name : path + "." + name;
+}
+
+}  // namespace schemaregistry::serdes

--- a/src/serdes/avro/AvroSerializer.cpp
+++ b/src/serdes/avro/AvroSerializer.cpp
@@ -91,9 +91,49 @@ void AvroSerde::resolveNamedSchema(
     }
 }
 
+std::shared_ptr<const std::pair<nlohmann::json, std::vector<nlohmann::json>>>
+AvroSerde::getSchemaJsons(
+    const schemaregistry::rest::model::Schema &schema,
+    std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client) {
+    if (!schema.getSchema().has_value()) {
+        return nullptr;
+    }
+    // getSchema() returns by value, so the string must be copied rather than
+    // bound to a reference into the returned temporary.
+    const std::string cache_key = schema.getSchema().value();
+
+    {
+        std::shared_lock lock(mutex_);
+        auto it = schema_jsons_.find(cache_key);
+        if (it != schema_jsons_.end()) {
+            return it->second;
+        }
+    }
+
+    std::vector<std::string> named_schema_strings;
+    std::unordered_set<std::string> visited;
+    resolveNamedSchema(schema, client, named_schema_strings, visited);
+
+    std::vector<nlohmann::json> named_schemas;
+    named_schemas.reserve(named_schema_strings.size());
+    for (const auto &named : named_schema_strings) {
+        named_schemas.push_back(nlohmann::json::parse(named));
+    }
+    auto result = std::make_shared<
+        const std::pair<nlohmann::json, std::vector<nlohmann::json>>>(
+        nlohmann::json::parse(cache_key), std::move(named_schemas));
+
+    {
+        std::unique_lock lock(mutex_);
+        schema_jsons_[cache_key] = result;
+    }
+    return result;
+}
+
 void AvroSerde::clear() {
     std::unique_lock lock(mutex_);
     parsed_schemas_.clear();
+    schema_jsons_.clear();
 }
 
 // AvroSerializer implementation (PIMPL)
@@ -172,7 +212,7 @@ class AvroSerializer::Impl {
 
             if (base_->validationEnabled(
                     ValidationRulesExecution::BeforeDomainRules)) {
-                validateInlineRules(schema_json, value);
+                validateInlineRules(schema, value);
             }
 
             // Create field transformer lambda
@@ -208,7 +248,7 @@ class AvroSerializer::Impl {
 
             if (base_->validationEnabled(
                     ValidationRulesExecution::AfterDomainRules)) {
-                validateInlineRules(schema_json, value);
+                validateInlineRules(schema, value);
             }
         } else {
             // Use provided schema and register/lookup
@@ -220,8 +260,7 @@ class AvroSerializer::Impl {
             // No domain rules run on this path, so there is a single validation
             // point regardless of the configured phase.
             if (base_->validationEnabled(std::nullopt)) {
-                validateInlineRules(
-                    nlohmann::json::parse(schema_->getSchema().value()), value);
+                validateInlineRules(schema_.value(), value);
             }
 
             schemaregistry::rest::model::RegisteredSchema registered_schema;
@@ -292,11 +331,20 @@ class AvroSerializer::Impl {
 
     // Evaluate the schema's inline validation rules against datum, throwing a
     // single error listing every violation found.
-    void validateInlineRules(const nlohmann::json &schema_json,
-                             const ::avro::GenericDatum &datum) {
+    void validateInlineRules(
+        const schemaregistry::rest::model::Schema &target_schema,
+        const ::avro::GenericDatum &datum) {
+        // The schema JSON and the schemas it references are cached, so this
+        // neither re-parses the schema text per message nor loses rules
+        // declared in a referenced schema.
+        auto schema_jsons = serde_->getSchemaJsons(
+            target_schema, base_->getSerde().getClient());
+        if (!schema_jsons) {
+            return;
+        }
         auto executor = base_->validationExecutor();
         raiseValidationViolations(utils::validateMessage(
-            *executor, schema_json, datum,
+            *executor, schema_jsons->first, schema_jsons->second, datum,
             base_->getConfig().validation_rules_fail_fast));
     }
 

--- a/src/serdes/avro/AvroSerializer.cpp
+++ b/src/serdes/avro/AvroSerializer.cpp
@@ -14,10 +14,7 @@ std::pair<::avro::ValidSchema, std::vector<::avro::ValidSchema>>
 AvroSerde::getParsedSchema(
     const schemaregistry::rest::model::Schema &schema,
     std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client) {
-    // Generate cache key (reuse the updated SerdeTypes cache key generation)
-    nlohmann::json j;
-    to_json(j, schema);
-    std::string cache_key = j.dump();
+    std::string cache_key = schemaCacheKey(schema);
 
     // Check cache first
     {
@@ -98,9 +95,9 @@ AvroSerde::getSchemaJsons(
     if (!schema.getSchema().has_value()) {
         return nullptr;
     }
-    // getSchema() returns by value, so the string must be copied rather than
-    // bound to a reference into the returned temporary.
-    const std::string cache_key = schema.getSchema().value();
+    // Keyed on the whole schema, matching getParsedSchema: the referenced
+    // schemas returned alongside the root are part of what this resolves to.
+    const std::string cache_key = schemaCacheKey(schema);
 
     {
         std::shared_lock lock(mutex_);
@@ -121,7 +118,8 @@ AvroSerde::getSchemaJsons(
     }
     auto result = std::make_shared<
         const std::pair<nlohmann::json, std::vector<nlohmann::json>>>(
-        nlohmann::json::parse(cache_key), std::move(named_schemas));
+        nlohmann::json::parse(schema.getSchema().value()),
+        std::move(named_schemas));
 
     {
         std::unique_lock lock(mutex_);

--- a/src/serdes/avro/AvroSerializer.cpp
+++ b/src/serdes/avro/AvroSerializer.cpp
@@ -165,8 +165,15 @@ class AvroSerializer::Impl {
                                  latest_schema->getGuid(), std::nullopt);
 
             auto schema = latest_schema->toSchema();
+            auto schema_json =
+                nlohmann::json::parse(schema.getSchema().value());
             auto parsed_schema =
                 serde_->getParsedSchema(schema, base_->getSerde().getClient());
+
+            if (base_->validationEnabled(
+                    ValidationRulesExecution::BeforeDomainRules)) {
+                validateInlineRules(schema_json, value);
+            }
 
             // Create field transformer lambda
             auto field_transformer =
@@ -188,8 +195,7 @@ class AvroSerializer::Impl {
             auto transformed_value = base_->getSerde().executeRules(
                 ctx, subject, Mode::Write, std::nullopt,
                 std::make_optional(schema), *avro_value,
-                utils::getInlineTags(
-                    nlohmann::json::parse(schema.getSchema().value())),
+                utils::getInlineTags(schema_json),
                 std::make_shared<FieldTransformer>(field_transformer));
 
             // Extract Avro value from result
@@ -199,11 +205,23 @@ class AvroSerializer::Impl {
                 throw AvroError(
                     "Unexpected serde value type returned from rule execution");
             }
+
+            if (base_->validationEnabled(
+                    ValidationRulesExecution::AfterDomainRules)) {
+                validateInlineRules(schema_json, value);
+            }
         } else {
             // Use provided schema and register/lookup
             if (!schema_.has_value()) {
                 throw AvroError(
                     "No schema provided and none found in registry");
+            }
+
+            // No domain rules run on this path, so there is a single validation
+            // point regardless of the configured phase.
+            if (base_->validationEnabled(std::nullopt)) {
+                validateInlineRules(
+                    nlohmann::json::parse(schema_->getSchema().value()), value);
             }
 
             schemaregistry::rest::model::RegisteredSchema registered_schema;
@@ -270,6 +288,16 @@ class AvroSerializer::Impl {
         if (serde_) {
             serde_->clear();
         }
+    }
+
+    // Evaluate the schema's inline validation rules against datum, throwing a
+    // single error listing every violation found.
+    void validateInlineRules(const nlohmann::json &schema_json,
+                             const ::avro::GenericDatum &datum) {
+        auto executor = base_->validationExecutor();
+        raiseValidationViolations(utils::validateMessage(
+            *executor, schema_json, datum,
+            base_->getConfig().validation_rules_fail_fast));
     }
 
     std::pair<::avro::ValidSchema, std::vector<::avro::ValidSchema>>

--- a/src/serdes/avro/AvroUtils.cpp
+++ b/src/serdes/avro/AvroUtils.cpp
@@ -69,24 +69,35 @@ namespace utils {
         }
 
         case ::avro::AVRO_UNION: {
-            auto union_val = datum.value<::avro::GenericUnion>();
             auto [branch_idx, branch_schema] = resolveUnion(schema, datum);
-            auto transformed =
-                transformFields(ctx, branch_schema, union_val.datum());
 
-            ::avro::GenericDatum result_datum(schema);
-            auto &result = result_datum.value<::avro::GenericUnion>();
+            // GenericDatum resolves a union on the way in: type() reports the
+            // branch's type and value<T>() reaches the branch's value, so the
+            // branch datum to walk is the datum itself. Asking a union datum for
+            // its GenericUnion instead casts the *branch's* value to
+            // GenericUnion, which any_cast rejects, leaving a null to
+            // dereference.
+            auto transformed = transformFields(ctx, branch_schema, datum);
+
+            // The union has to be rebuilt through GenericUnion rather than
+            // through the datum, for the same reason: a GenericDatum holding a
+            // union will not hand its GenericUnion back. This constructor
+            // assigns into the value directly, without that resolution step.
+            ::avro::GenericUnion result(schema.root());
             result.selectBranch(branch_idx);
             result.datum() = transformed;
-
-            return result_datum;
+            return ::avro::GenericDatum(schema.root(), result);
         }
 
         default: {
             // Field-level transformation logic
             auto field_ctx = ctx.currentField();
             if (field_ctx.has_value()) {
-                field_ctx->setFieldType(avroSchemaToFieldType(schema));
+                // The field was entered with the type its schema declares,
+                // which for a union field is only Combined. Narrow it to the
+                // type of the branch the value holds, so that a rule on, say, a
+                // ["null","string"] field sees a string.
+                ctx.setCurrentFieldType(avroSchemaToFieldType(schema));
 
                 auto rule_tags = ctx.getRule().getTags();
                 std::unordered_set<std::string> rule_tags_set;
@@ -308,10 +319,9 @@ nlohmann::json avroToJson(const ::avro::GenericDatum &datum) {
             return json_obj;
         }
 
-        case ::avro::AVRO_UNION: {
-            const auto &union_val = datum.value<::avro::GenericUnion>();
-            return avroToJson(union_val.datum());
-        }
+        // No AVRO_UNION arm: type() reports the type of the branch a union
+        // holds, never AVRO_UNION, so a union datum is already handled by the
+        // arm for the branch it holds.
 
         default:
             throw AvroError("Unsupported Avro type for JSON conversion");
@@ -442,19 +452,66 @@ nlohmann::json avroToJson(const ::avro::GenericDatum &datum) {
     }
 }
 
+namespace {
+
+// The fullname of a record, enum or fixed datum. This is what tells such a
+// datum apart from another union branch of the same Avro type; the remaining
+// types are unnamed, and their type alone identifies the branch.
+std::optional<std::string> datumTypeName(const ::avro::GenericDatum &datum) {
+    switch (datum.type()) {
+        case ::avro::AVRO_RECORD:
+            return datum.value<::avro::GenericRecord>()
+                .schema()
+                ->name()
+                .fullname();
+        case ::avro::AVRO_ENUM:
+            return datum.value<::avro::GenericEnum>()
+                .schema()
+                ->name()
+                .fullname();
+        case ::avro::AVRO_FIXED:
+            return datum.value<::avro::GenericFixed>()
+                .schema()
+                ->name()
+                .fullname();
+        default:
+            return std::nullopt;
+    }
+}
+
+}  // namespace
+
 std::pair<size_t, ::avro::ValidSchema> resolveUnion(
     const ::avro::ValidSchema &union_schema,
     const ::avro::GenericDatum &datum) {
-    if (union_schema.root()->type() != ::avro::AVRO_UNION) {
+    const auto &root = union_schema.root();
+    if (root->type() != ::avro::AVRO_UNION) {
         throw AvroError("Schema is not a union type");
     }
 
-    // Try to find matching branch based on datum type
-    for (size_t i = 0; i < union_schema.root()->leaves(); ++i) {
-        auto branch_schema = union_schema.root()->leafAt(i);
-        if (branch_schema->type() == datum.type()) {
-            return {i, ::avro::ValidSchema(branch_schema)};
+    // A datum that carries a union records the branch it holds, and that is the
+    // only reliable answer. GenericDatum::type() reports the type of the branch
+    // rather than AVRO_UNION, and a type does not identify a branch: a union of
+    // two records is told apart by name alone, so matching on type would return
+    // the first record in the union whichever one the datum holds.
+    if (datum.isUnion() && datum.unionBranch() < root->leaves()) {
+        size_t branch = datum.unionBranch();
+        return {branch, ::avro::ValidSchema(root->leafAt(branch))};
+    }
+
+    // A datum handed in without its union wrapper has to be matched on what it
+    // does carry: its type, and its name where it has one.
+    auto datum_name = datumTypeName(datum);
+    for (size_t i = 0; i < root->leaves(); ++i) {
+        const auto &branch_schema = root->leafAt(i);
+        if (branch_schema->type() != datum.type()) {
+            continue;
         }
+        if (datum_name.has_value() && branch_schema->hasName() &&
+            branch_schema->name().fullname() != *datum_name) {
+            continue;
+        }
+        return {i, ::avro::ValidSchema(branch_schema)};
     }
 
     throw AvroError("No matching union branch found for datum type");

--- a/src/serdes/avro/AvroUtils.cpp
+++ b/src/serdes/avro/AvroUtils.cpp
@@ -471,7 +471,8 @@ std::vector<uint8_t> serializeAvroData(
     const ::avro::GenericDatum &datum, const ::avro::ValidSchema &writer_schema,
     const std::vector<::avro::ValidSchema> &named_schemas) {
     try {
-        // If the writer schema is AVRO_BYTES, just return the raw bytes directly
+        // If the writer schema is AVRO_BYTES, just return the raw bytes
+        // directly
         if (writer_schema.root()->type() == ::avro::AVRO_BYTES) {
             return datum.value<std::vector<uint8_t>>();
         }
@@ -501,7 +502,8 @@ std::vector<uint8_t> serializeAvroData(
     const ::avro::ValidSchema *reader_schema,
     const std::vector<::avro::ValidSchema> &named_schemas) {
     try {
-        // If the writer schema is AVRO_BYTES, just return the raw bytes directly
+        // If the writer schema is AVRO_BYTES, just return the raw bytes
+        // directly
         if (writer_schema.root()->type() == ::avro::AVRO_BYTES) {
             ::avro::GenericDatum datum(writer_schema);
             datum.value<std::vector<uint8_t>>() = data;
@@ -601,22 +603,29 @@ void getInlineTagsRecursively(
             std::string record_ns;
             std::string record_name;
 
-            auto ns_it = schema.find("namespace");
-            if (ns_it != schema.end() && ns_it->is_string()) {
-                record_ns = ns_it->get<std::string>();
-            } else {
-                record_ns = impliedNamespace(name);
-                if (record_ns.empty()) {
-                    record_ns = ns;
-                }
-            }
-
             auto name_it = schema.find("name");
             if (name_it != schema.end() && name_it->is_string()) {
                 record_name = name_it->get<std::string>();
+            }
 
-                // Add namespace prefix if needed
-                if (!record_ns.empty() && record_name.find(record_ns) != 0) {
+            if (record_name.find('.') != std::string::npos) {
+                // A name containing a dot is already a fullname; Avro ignores
+                // any namespace attribute for it.
+                record_ns = impliedNamespace(record_name);
+            } else {
+                auto ns_it = schema.find("namespace");
+                if (ns_it != schema.end() && ns_it->is_string()) {
+                    record_ns = ns_it->get<std::string>();
+                } else {
+                    record_ns = impliedNamespace(name);
+                    if (record_ns.empty()) {
+                        record_ns = ns;
+                    }
+                }
+                // The namespace is a prefix to prepend, not a prefix to test
+                // for: a record named "foobar" in namespace "foo" is
+                // "foo.foobar", not "foobar".
+                if (!record_ns.empty() && !record_name.empty()) {
                     record_name = record_ns + "." + record_name;
                 }
             }

--- a/src/serdes/avro/AvroUtils.cpp
+++ b/src/serdes/avro/AvroUtils.cpp
@@ -663,10 +663,15 @@ void getInlineTagsRecursively(
  */
 void removeConfluentTags(nlohmann::json &schema) {
     if (schema.is_object()) {
-        // Remove confluent:tags if it exists
+        // Remove the confluent-specific attributes if they exist; the Avro
+        // parser rejects schemas carrying them.
         auto tags_it = schema.find("confluent:tags");
         if (tags_it != schema.end()) {
             schema.erase(tags_it);
+        }
+        auto rules_it = schema.find(VALIDATION_RULES_PROP);
+        if (rules_it != schema.end()) {
+            schema.erase(rules_it);
         }
 
         // Recursively process all values in the object

--- a/src/serdes/avro/AvroValidate.cpp
+++ b/src/serdes/avro/AvroValidate.cpp
@@ -83,6 +83,13 @@ struct Walker {
     void walk(const nlohmann::json &schema, const std::string &ns,
               const ::avro::GenericDatum &datum, const std::string &path);
 
+    /**
+     * Registers every named definition reachable from schema, without
+     * evaluating rules.
+     * Used to seed the walk with the referenced schemas.
+     */
+    void collectNamed(const nlohmann::json &schema, const std::string &ns);
+
     void walkRecord(const nlohmann::json &schema, const std::string &ns,
                     const ::avro::GenericDatum &datum, const std::string &path);
 };
@@ -149,6 +156,81 @@ void Walker::walkRecord(const nlohmann::json &schema, const std::string &ns,
         walk(*field_type_it, record_ns, field_datum, field_path);
         if (done()) {
             return;
+        }
+    }
+}
+
+void Walker::collectNamed(const nlohmann::json &schema, const std::string &ns) {
+    if (schema.is_array()) {
+        for (const auto &variant : schema) {
+            collectNamed(variant, ns);
+        }
+        return;
+    }
+    if (!schema.is_object()) {
+        return;
+    }
+    auto type_it = schema.find("type");
+    if (type_it == schema.end()) {
+        return;
+    }
+    if (!type_it->is_string()) {
+        collectNamed(*type_it, ns);
+        return;
+    }
+    std::string type = type_it->get<std::string>();
+    if (type == "array") {
+        auto items_it = schema.find("items");
+        if (items_it != schema.end()) {
+            collectNamed(*items_it, ns);
+        }
+        return;
+    }
+    if (type == "map") {
+        auto values_it = schema.find("values");
+        if (values_it != schema.end()) {
+            collectNamed(*values_it, ns);
+        }
+        return;
+    }
+    if (type != "record") {
+        return;
+    }
+
+    std::string record_ns = ns;
+    std::string record_name;
+    auto name_it = schema.find("name");
+    if (name_it != schema.end() && name_it->is_string()) {
+        record_name = name_it->get<std::string>();
+    }
+    if (record_name.find('.') != std::string::npos) {
+        record_ns = impliedNamespace(record_name);
+        named[record_name] = &schema;
+    } else {
+        auto ns_it = schema.find("namespace");
+        if (ns_it != schema.end() && ns_it->is_string()) {
+            record_ns = ns_it->get<std::string>();
+        }
+        if (!record_name.empty()) {
+            named[record_ns.empty() ? record_name
+                                    : record_ns + "." + record_name] = &schema;
+            if (record_ns.empty()) {
+                named[record_name] = &schema;
+            }
+        }
+    }
+
+    auto fields_it = schema.find("fields");
+    if (fields_it == schema.end() || !fields_it->is_array()) {
+        return;
+    }
+    for (const auto &field : *fields_it) {
+        if (!field.is_object()) {
+            continue;
+        }
+        auto field_type_it = field.find("type");
+        if (field_type_it != field.end()) {
+            collectNamed(*field_type_it, record_ns);
         }
     }
 }
@@ -222,9 +304,16 @@ void Walker::walk(const nlohmann::json &schema, const std::string &ns,
 
 std::vector<ValidationRuleError> validateMessage(
     ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const std::vector<nlohmann::json> &named_schemas,
     const ::avro::GenericDatum &datum, bool fail_fast) {
     std::vector<ValidationRuleError> violations;
     Walker walker{executor, fail_fast, violations, {}};
+    // Index the referenced schemas first: a field may name a record defined in
+    // another subject, and without their definitions those rules would be
+    // silently skipped.
+    for (const auto &named : named_schemas) {
+        walker.collectNamed(named, "");
+    }
     walker.walk(schema, "", datum, "");
     return violations;
 }

--- a/src/serdes/avro/AvroValidate.cpp
+++ b/src/serdes/avro/AvroValidate.cpp
@@ -1,0 +1,232 @@
+#include <avro/Generic.hh>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "schemaregistry/serdes/ValidationRule.h"
+#include "schemaregistry/serdes/avro/AvroTypes.h"
+#include "schemaregistry/serdes/avro/AvroUtils.h"
+
+namespace schemaregistry::serdes::avro::utils {
+
+namespace {
+
+/**
+ * Named record schemas encountered so far, keyed by fully-qualified name, so
+ * that a field declared as a bare type name (e.g. "com.example.Address") can be
+ * resolved back to the schema object carrying its inline rules. Avro requires a
+ * name to be defined before it is referenced, and a record's own name is
+ * registered before its fields are walked, so recursive types resolve too.
+ */
+using NamedSchemas = std::unordered_map<std::string, const nlohmann::json *>;
+
+struct Walker {
+    ValidationRuleExecutor &executor;
+    bool fail_fast;
+    std::vector<ValidationRuleError> &violations;
+    NamedSchemas named;
+
+    bool done() const { return fail_fast && !violations.empty(); }
+
+    /**
+     * Evaluate the inline rules declared on schema against datum. Skips null
+     * values, honoring the skip-on-null contract.
+     */
+    bool evaluateRules(const nlohmann::json &schema,
+                       const ::avro::GenericDatum &datum,
+                       const std::string &path) {
+        if (datum.type() == ::avro::AVRO_NULL) {
+            return false;
+        }
+        auto rules_it = schema.find(VALIDATION_RULES_PROP);
+        if (rules_it == schema.end()) {
+            return false;
+        }
+        auto rules = parseValidationRules(*rules_it);
+        if (rules.empty()) {
+            return false;
+        }
+        auto value = makeAvroValue(datum);
+        for (const auto &rule : rules) {
+            evaluateValidationRule(executor, rule, *value, path, violations);
+            if (done()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolve a schema node to the object that may carry inline rules: a bare
+     * string is either a primitive type or a reference to a named schema.
+     */
+    const nlohmann::json *resolve(const nlohmann::json &schema,
+                                  const std::string &ns) {
+        if (!schema.is_string()) {
+            return &schema;
+        }
+        std::string name = schema.get<std::string>();
+        auto it = named.find(name);
+        if (it != named.end()) {
+            return it->second;
+        }
+        if (!ns.empty()) {
+            it = named.find(ns + "." + name);
+            if (it != named.end()) {
+                return it->second;
+            }
+        }
+        return nullptr;
+    }
+
+    void walk(const nlohmann::json &schema, const std::string &ns,
+              const ::avro::GenericDatum &datum, const std::string &path);
+
+    void walkRecord(const nlohmann::json &schema, const std::string &ns,
+                    const ::avro::GenericDatum &datum, const std::string &path);
+};
+
+void Walker::walkRecord(const nlohmann::json &schema, const std::string &ns,
+                        const ::avro::GenericDatum &datum,
+                        const std::string &path) {
+    std::string record_ns = ns;
+    auto ns_it = schema.find("namespace");
+    if (ns_it != schema.end() && ns_it->is_string()) {
+        record_ns = ns_it->get<std::string>();
+    }
+
+    auto name_it = schema.find("name");
+    if (name_it != schema.end() && name_it->is_string()) {
+        std::string name = name_it->get<std::string>();
+        // A name containing a dot is already fully qualified and also carries
+        // its own namespace for nested definitions.
+        auto dot = name.rfind('.');
+        if (dot != std::string::npos) {
+            record_ns = name.substr(0, dot);
+            named[name] = &schema;
+        } else {
+            named[record_ns.empty() ? name : record_ns + "." + name] = &schema;
+            if (record_ns.empty()) {
+                named[name] = &schema;
+            }
+        }
+    }
+
+    // Record-level rules: `this` is the record itself.
+    if (evaluateRules(schema, datum, path)) {
+        return;
+    }
+
+    auto fields_it = schema.find("fields");
+    if (fields_it == schema.end() || !fields_it->is_array() ||
+        datum.type() != ::avro::AVRO_RECORD) {
+        return;
+    }
+    const auto &record = datum.value<::avro::GenericRecord>();
+
+    for (const auto &field : *fields_it) {
+        if (!field.is_object()) {
+            continue;
+        }
+        auto field_name_it = field.find("name");
+        auto field_type_it = field.find("type");
+        if (field_name_it == field.end() || !field_name_it->is_string() ||
+            field_type_it == field.end()) {
+            continue;
+        }
+        std::string field_name = field_name_it->get<std::string>();
+        if (!record.hasField(field_name)) {
+            continue;
+        }
+        const auto &field_datum = record.field(field_name);
+        std::string field_path = appendValidationPath(path, field_name);
+
+        // Field-level rules: `this` is the field value.
+        if (evaluateRules(field, field_datum, field_path)) {
+            return;
+        }
+        walk(*field_type_it, record_ns, field_datum, field_path);
+        if (done()) {
+            return;
+        }
+    }
+}
+
+void Walker::walk(const nlohmann::json &schema, const std::string &ns,
+                  const ::avro::GenericDatum &datum, const std::string &path) {
+    if (done()) {
+        return;
+    }
+
+    if (schema.is_array()) {
+        // A union: descend into the branch the datum actually holds.
+        size_t branch = datum.isUnion() ? datum.unionBranch() : 0;
+        if (branch < schema.size()) {
+            walk(schema[branch], ns, datum, path);
+        }
+        return;
+    }
+
+    const nlohmann::json *resolved = resolve(schema, ns);
+    if (resolved == nullptr || !resolved->is_object()) {
+        return;
+    }
+    const nlohmann::json &node = *resolved;
+
+    auto type_it = node.find("type");
+    if (type_it == node.end()) {
+        return;
+    }
+    // A field's "type" may itself be a union or a named reference rather than a
+    // type keyword.
+    if (!type_it->is_string()) {
+        walk(*type_it, ns, datum, path);
+        return;
+    }
+    std::string type = type_it->get<std::string>();
+
+    if (type == "record") {
+        walkRecord(node, ns, datum, path);
+    } else if (type == "array") {
+        auto items_it = node.find("items");
+        if (items_it == node.end() || datum.type() != ::avro::AVRO_ARRAY) {
+            return;
+        }
+        const auto &array = datum.value<::avro::GenericArray>().value();
+        for (size_t i = 0; i < array.size(); ++i) {
+            walk(*items_it, ns, array[i], path + "[" + std::to_string(i) + "]");
+            if (done()) {
+                return;
+            }
+        }
+    } else if (type == "map") {
+        auto values_it = node.find("values");
+        if (values_it == node.end() || datum.type() != ::avro::AVRO_MAP) {
+            return;
+        }
+        const auto &map = datum.value<::avro::GenericMap>().value();
+        for (const auto &entry : map) {
+            walk(*values_it, ns, entry.second,
+                 path + "[\"" + entry.first + "\"]");
+            if (done()) {
+                return;
+            }
+        }
+    }
+    // Anything else is a primitive, enum or fixed: no children to descend into,
+    // and its rules were evaluated by the declaring record.
+}
+
+}  // namespace
+
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const ::avro::GenericDatum &datum, bool fail_fast) {
+    std::vector<ValidationRuleError> violations;
+    Walker walker{executor, fail_fast, violations, {}};
+    walker.walk(schema, "", datum, "");
+    return violations;
+}
+
+}  // namespace schemaregistry::serdes::avro::utils

--- a/src/serdes/json/JsonSerializer.cpp
+++ b/src/serdes/json/JsonSerializer.cpp
@@ -157,9 +157,38 @@ JsonSerde::getParsedSchema(
     return compiled_schema;
 }
 
+std::shared_ptr<const nlohmann::json> JsonSerde::getSchemaJson(
+    const schemaregistry::rest::model::Schema& schema,
+    std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client) {
+    auto schema_str = schema.getSchema();
+    if (!schema_str.has_value()) {
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto it = schema_json_cache_.find(schema_str.value());
+    if (it != schema_json_cache_.end()) {
+        return it->second;
+    }
+
+    // Resolve and inline references the same way getParsedSchema does, so that a $ref
+    // into a referenced schema becomes a local pointer the walker can follow, and so
+    // that the schema text is not re-parsed for every message.
+    std::unordered_set<std::string> visited;
+    auto resolved_refs =
+        schema_resolution::resolveNamedSchema(schema, client, visited);
+    auto flattened = flattenSchemaReferences(
+        nlohmann::json::parse(schema_str.value()), resolved_refs);
+
+    auto parsed = std::make_shared<const nlohmann::json>(std::move(flattened));
+    schema_json_cache_[schema_str.value()] = parsed;
+    return parsed;
+}
+
 void JsonSerde::clear() {
     std::lock_guard<std::mutex> lock(cache_mutex_);
     parsed_schemas_cache_.clear();
+    schema_json_cache_.clear();
 }
 
 void JsonSerde::resolveNamedSchema(
@@ -384,13 +413,16 @@ class JsonSerializer::Impl {
     void validateInlineRules(
         const schemaregistry::rest::model::Schema& target_schema,
         const nlohmann::json& value) {
-        auto schema_str = target_schema.getSchema();
-        if (!schema_str.has_value()) {
+        // The schema JSON is resolved and cached, so this neither re-parses the schema
+        // text per message nor loses rules declared in a referenced schema.
+        auto schema_json = serde_->getSchemaJson(
+            target_schema, base_->getSerde().getClient());
+        if (!schema_json) {
             return;
         }
         auto executor = base_->validationExecutor();
         raiseValidationViolations(utils::validateMessage(
-            *executor, nlohmann::json::parse(schema_str.value()), value,
+            *executor, *schema_json, value,
             base_->getConfig().validation_rules_fail_fast));
     }
 

--- a/src/serdes/json/JsonSerializer.cpp
+++ b/src/serdes/json/JsonSerializer.cpp
@@ -119,9 +119,9 @@ JsonSerde::getParsedSchema(
     std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client) {
     std::lock_guard<std::mutex> lock(cache_mutex_);
 
-    // Create cache key from schema content
-    auto schema_str = schema.getSchema();
-    std::string cache_key = schema_str.value_or("");
+    // Keyed on the whole schema: what gets compiled below is the schema with
+    // its references flattened in, so the references are part of its identity.
+    std::string cache_key = schemaCacheKey(schema);
 
     auto it = parsed_schemas_cache_.find(cache_key);
     if (it != parsed_schemas_cache_.end()) {
@@ -136,7 +136,7 @@ JsonSerde::getParsedSchema(
     // Parse main schema
     nlohmann::json parsed_schema;
     try {
-        parsed_schema = nlohmann::json::parse(cache_key);
+        parsed_schema = nlohmann::json::parse(schema.getSchema().value_or(""));
     } catch (const nlohmann::json::parse_error &e) {
         throw JsonError("Failed to parse JSON schema: " +
                         std::string(e.what()));
@@ -165,8 +165,13 @@ std::shared_ptr<const nlohmann::json> JsonSerde::getSchemaJson(
         return nullptr;
     }
 
+    // Keyed on the whole schema for the same reason getParsedSchema is: the
+    // flattened document below inlines what the references resolve to, inline
+    // validation rules included.
+    const std::string cache_key = schemaCacheKey(schema);
+
     std::lock_guard<std::mutex> lock(cache_mutex_);
-    auto it = schema_json_cache_.find(schema_str.value());
+    auto it = schema_json_cache_.find(cache_key);
     if (it != schema_json_cache_.end()) {
         return it->second;
     }
@@ -181,7 +186,7 @@ std::shared_ptr<const nlohmann::json> JsonSerde::getSchemaJson(
         nlohmann::json::parse(schema_str.value()), resolved_refs);
 
     auto parsed = std::make_shared<const nlohmann::json>(std::move(flattened));
-    schema_json_cache_[schema_str.value()] = parsed;
+    schema_json_cache_[cache_key] = parsed;
     return parsed;
 }
 

--- a/src/serdes/json/JsonSerializer.cpp
+++ b/src/serdes/json/JsonSerializer.cpp
@@ -260,6 +260,11 @@ class JsonSerializer::Impl {
             // Get parsed schema
             parsed_schema = getParsedSchema(target_schema);
 
+            if (base_->validationEnabled(
+                    ValidationRulesExecution::BeforeDomainRules)) {
+                validateInlineRules(target_schema, mutable_value);
+            }
+
             // Create field transformer lambda
             auto field_transformer =
                 [this, &parsed_schema](
@@ -289,12 +294,23 @@ class JsonSerializer::Impl {
                 throw JsonError(
                     "Unexpected serde value type returned from rule execution");
             }
+
+            if (base_->validationEnabled(
+                    ValidationRulesExecution::AfterDomainRules)) {
+                validateInlineRules(target_schema, mutable_value);
+            }
         } else {
             // Use provided schema
             if (!schema_.has_value()) {
                 throw JsonError("Schema needs to be set for auto-registration");
             }
             target_schema = schema_.value();
+
+            // No domain rules run on this path, so there is a single validation
+            // point regardless of the configured phase.
+            if (base_->validationEnabled(std::nullopt)) {
+                validateInlineRules(target_schema, mutable_value);
+            }
 
             // Register or get schema
             if (base_->getConfig().auto_register_schemas) {
@@ -362,6 +378,21 @@ class JsonSerializer::Impl {
     }
 
     void close() { serde_->clear(); }
+
+    // Evaluate the schema's inline validation rules against value, throwing a
+    // single error listing every violation found.
+    void validateInlineRules(
+        const schemaregistry::rest::model::Schema& target_schema,
+        const nlohmann::json& value) {
+        auto schema_str = target_schema.getSchema();
+        if (!schema_str.has_value()) {
+            return;
+        }
+        auto executor = base_->validationExecutor();
+        raiseValidationViolations(utils::validateMessage(
+            *executor, nlohmann::json::parse(schema_str.value()), value,
+            base_->getConfig().validation_rules_fail_fast));
+    }
 
     std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>>
     getParsedSchema(const schemaregistry::rest::model::Schema &schema) {

--- a/src/serdes/json/JsonUtils.cpp
+++ b/src/serdes/json/JsonUtils.cpp
@@ -1,6 +1,7 @@
 #include "schemaregistry/serdes/json/JsonUtils.h"
 
 #include <algorithm>
+#include <exception>
 #include <sstream>
 
 #include "schemaregistry/serdes/RuleRegistry.h"  // For global_registry functions
@@ -80,11 +81,16 @@ nlohmann::json transformFields(
     // Track visited locations to avoid duplicate transformations
     std::unordered_set<std::string> visited_locations;
 
-    // Use the schema's walk method to traverse and transform the JSON structure
+    // A field whose transform fails must not be passed through unchanged: for a
+    // field-encryption rule that would emit the plaintext and report success. The walk
+    // callback cannot throw through jsoncons, so the first failure is captured, the walk is
+    // aborted, and it is rethrown to the caller below.
+    std::exception_ptr failure;
+
     try {
         schema->walk(
             mutable_value,
-            [&ctx, &mutable_value, &visited_locations](
+            [&ctx, &mutable_value, &visited_locations, &failure](
                 const std::string &keyword, const jsoncons::ojson &schema_node,
                 const jsoncons::uri &schema_location,
                 const jsoncons::ojson &instance_node,
@@ -139,34 +145,34 @@ nlohmann::json transformFields(
                                         : "";
 
                                 // Update the mutable_value using the JSON
-                                // pointer
-                                try {
-                                    jsoncons::jsonpointer::replace(
-                                        mutable_value, field_location,
-                                        transformed_value);
-                                } catch (const std::exception &e) {
-                                    // If pointer access fails, continue with
-                                    // next field
-                                }
+                                // pointer. A transformed value that cannot be
+                                // written back is a failure, not something to
+                                // skip - the field would keep its original
+                                // value.
+                                jsoncons::jsonpointer::replace(
+                                    mutable_value, field_location,
+                                    transformed_value);
                             }
                         }
                     }
-                } catch (const std::exception &e) {
-                    // Continue processing even if a single field transformation
-                    // fails This maintains consistency with the recursive
-                    // approach
+                } catch (...) {
+                    failure = std::current_exception();
+                    return jsoncons::jsonschema::walk_result::abort;
                 }
 
                 return jsoncons::jsonschema::walk_result::advance;
             });
-
-        // Convert back to nlohmann::json and return
-        return ojsonToJson(mutable_value);
-
-    } catch (const std::exception &e) {
-        // If walk fails, fall back to the original value
-        return value;
+    } catch (...) {
+        // The walk itself failed rather than a field within it.
+        if (!failure) {
+            failure = std::current_exception();
+        }
     }
+
+    if (failure) {
+        std::rethrow_exception(failure);
+    }
+    return ojsonToJson(mutable_value);
 }
 
 jsoncons::ojson transformFieldWithContext(RuleContext &ctx,
@@ -285,30 +291,65 @@ jsoncons::ojson transform(RuleContext &ctx, const jsoncons::ojson &schema,
 // Schema navigation implementations
 namespace schema_navigation {
 
-FieldType getFieldType(const jsoncons::ojson &schema) {
-    if (!schema.contains("type")) {
-        return FieldType::String;  // Default fallback
-    }
+namespace {
 
-    std::string type = schema["type"].as<std::string>();
-
+/// Maps a single JSON Schema type keyword. Null for anything this walk cannot act on -
+/// never String, which would hand an encryption rule a number or an object to encrypt as
+/// text.
+FieldType scalarFieldType(const std::string &type, bool has_properties) {
     if (type == "object") {
-        return FieldType::Record;
-    } else if (type == "array") {
-        return FieldType::Array;
-    } else if (type == "string") {
-        return FieldType::String;
-    } else if (type == "integer") {
-        return FieldType::Int;
-    } else if (type == "number") {
-        return FieldType::Double;
-    } else if (type == "boolean") {
-        return FieldType::Boolean;
-    } else if (type == "null") {
+        // An object with no declared properties is an open map.
+        return has_properties ? FieldType::Record : FieldType::Map;
+    }
+    if (type == "array") return FieldType::Array;
+    if (type == "string") return FieldType::String;
+    if (type == "integer") return FieldType::Int;
+    if (type == "number") return FieldType::Double;
+    if (type == "boolean") return FieldType::Boolean;
+    return FieldType::Null;
+}
+
+}  // namespace
+
+FieldType getFieldType(const jsoncons::ojson &schema) {
+    const bool has_properties = schema.contains("properties") &&
+                                schema["properties"].is_object() &&
+                                !schema["properties"].empty();
+    const bool has_combined = schema.contains("allOf") ||
+                              schema.contains("anyOf") ||
+                              schema.contains("oneOf");
+
+    if (!schema.contains("type")) {
+        if (has_properties) return FieldType::Record;
+        // A node built only from allOf/anyOf/oneOf is not any single type. Its branches
+        // are separate nodes and the walk types each of them on its own.
+        if (has_combined) return FieldType::Combined;
         return FieldType::Null;
     }
 
-    return FieldType::String;  // Default fallback
+    // A nullable field is written ["string", "null"], and the type that matters is the one
+    // that is not null - the JVM and Go clients reach the same place by narrowing the union
+    // to the branch the value matches. Only a union with several real types has no single
+    // type to act on.
+    if (schema["type"].is_array()) {
+        std::string single;
+        int count = 0;
+        for (const auto &entry : schema["type"].array_range()) {
+            if (!entry.is_string()) continue;
+            std::string type = entry.as<std::string>();
+            if (type == "null") continue;
+            single = type;
+            ++count;
+        }
+        if (count == 0) return FieldType::Null;
+        if (count > 1) return FieldType::Combined;
+        return scalarFieldType(single, has_properties);
+    }
+
+    if (schema.contains("const") || schema.contains("enum")) {
+        return FieldType::Enum;
+    }
+    return scalarFieldType(schema["type"].as<std::string>(), has_properties);
 }
 
 bool isObjectSchema(const jsoncons::ojson &schema) {

--- a/src/serdes/json/JsonUtils.cpp
+++ b/src/serdes/json/JsonUtils.cpp
@@ -319,6 +319,15 @@ FieldType getFieldType(const jsoncons::ojson &schema) {
                               schema.contains("anyOf") ||
                               schema.contains("oneOf");
 
+    // An enumeration is typed by its values, and JSON Schema does not require it to declare
+    // a type as well - {"enum": ["a", "b"]} is the ordinary form. This is checked before
+    // anything else so that form is not read as a typeless node: the JVM client answers ENUM
+    // for it, and ENUM is not a primitive, so a field rule that would otherwise be charged
+    // against it is skipped there and has to be here too.
+    if (schema.contains("const") || schema.contains("enum")) {
+        return FieldType::Enum;
+    }
+
     if (!schema.contains("type")) {
         if (has_properties) return FieldType::Record;
         // A node built only from allOf/anyOf/oneOf is not any single type. Its branches

--- a/src/serdes/json/JsonUtils.cpp
+++ b/src/serdes/json/JsonUtils.cpp
@@ -226,7 +226,7 @@ jsoncons::ojson transform(RuleContext &ctx, const jsoncons::ojson &schema,
     // Field-level transformation logic
     auto field_ctx = ctx.currentField();
     if (field_ctx.has_value()) {
-        field_ctx->setFieldType(schema_navigation::getFieldType(schema));
+        ctx.setCurrentFieldType(schema_navigation::getFieldType(schema));
 
         auto rule_tags = ctx.getRule().getTags();
         std::unordered_set<std::string> rule_tags_set;

--- a/src/serdes/json/JsonValidate.cpp
+++ b/src/serdes/json/JsonValidate.cpp
@@ -76,11 +76,41 @@ struct Walker {
     }
 
     /**
-     * Whether the instance could plausibly be described by the subschema, used
-     * to pick the live branch of a oneOf/anyOf. Only the declared "type" is
-     * considered: a full validation would need a compiled validator per branch,
-     * and getting this wrong would attribute violations to a branch the value
-     * does not follow.
+     * Whether the instance satisfies the subschema, used to pick the live
+     * branch of a
+     * oneOf/anyOf. Branches routinely share a JSON type and differ by const,
+     * required,
+     * ranges and so on, so the instance is validated against the whole
+     * subschema; a
+     * cheaper type comparison would evaluate rules from branches the value does
+     * not
+     * follow and reject valid messages.
+     *
+     * The root's definitions travel with the subschema, since references are
+     * flattened
+     * into them and a branch may point at one.
+     */
+    bool subschemaMatches(const nlohmann::json &subschema,
+                          const nlohmann::json &value) const {
+        try {
+            nlohmann::json standalone = subschema;
+            for (const char *defs : {"definitions", "$defs"}) {
+                auto it = root.find(defs);
+                if (it != root.end() && !standalone.contains(defs)) {
+                    standalone[defs] = *it;
+                }
+            }
+            auto compiled = jsoncons::jsonschema::make_json_schema(
+                utils::jsonToOJson(standalone));
+            return compiled.is_valid(utils::jsonToOJson(value));
+        } catch (const std::exception &) {
+            // An uncompilable branch cannot be the one the value follows.
+            return false;
+        }
+    }
+
+    /**
+     * Unused legacy helper kept out of the walk; see subschemaMatches.
      */
     static bool typeMatches(const nlohmann::json &schema,
                             const nlohmann::json &value) {
@@ -145,11 +175,17 @@ void Walker::walk(const nlohmann::json &schema, const nlohmann::json &value,
             continue;
         }
         bool all = std::string(keyword) == "allOf";
+        bool one = std::string(keyword) == "oneOf";
         for (const auto &branch : *branches_it) {
-            if (all || typeMatches(*resolveRef(branch), value)) {
+            if (all || subschemaMatches(*resolveRef(branch), value)) {
                 walk(branch, value, path);
                 if (done()) {
                     return;
+                }
+                if (one) {
+                    // oneOf has a single live branch; stop at the one that
+                    // matched.
+                    break;
                 }
             }
         }

--- a/src/serdes/json/JsonValidate.cpp
+++ b/src/serdes/json/JsonValidate.cpp
@@ -1,4 +1,6 @@
 #include <nlohmann/json.hpp>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,6 +17,11 @@ struct Walker {
     bool fail_fast;
     std::vector<ValidationRuleError> &violations;
     const nlohmann::json &root;
+    /// Compiled branch matchers, keyed by the branch's serialized form.
+    mutable std::map<
+        std::string,
+        std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>>>
+        matcher_cache;
 
     bool done() const { return fail_fast && !violations.empty(); }
 
@@ -76,41 +83,110 @@ struct Walker {
     }
 
     /**
-     * Whether the instance satisfies the subschema, used to pick the live
-     * branch of a
-     * oneOf/anyOf. Branches routinely share a JSON type and differ by const,
-     * required,
-     * ranges and so on, so the instance is validated against the whole
-     * subschema; a
-     * cheaper type comparison would evaluate rules from branches the value does
-     * not
-     * follow and reject valid messages.
-     *
-     * The root's definitions travel with the subschema, since references are
-     * flattened
-     * into them and a branch may point at one.
+     * The key the root document travels under inside a standalone branch document.
+     * Chosen to be one no schema would use.
      */
-    bool subschemaMatches(const nlohmann::json &subschema,
-                          const nlohmann::json &value) const {
-        try {
-            nlohmann::json standalone = subschema;
-            for (const char *defs : {"definitions", "$defs"}) {
-                auto it = root.find(defs);
-                if (it != root.end() && !standalone.contains(defs)) {
-                    standalone[defs] = *it;
+    static constexpr const char *kRootKey = "__confluent_root__";
+
+    /**
+     * Repoints every same-document reference at the copy of the root carried under
+     * kRootKey.
+     *
+     * A "#/..." reference is resolved against the document root, so a branch lifted out
+     * of its schema cannot follow one - "#/properties/shared" would be looked up in the
+     * branch. Rewriting them, in the branch and in the carried root alike, keeps every
+     * such reference pointing at the same node it named in the original document.
+     *
+     * References that name another document, or use $anchor or $dynamicRef, are left
+     * alone; they resolve the same way in either document.
+     */
+    static void repointFragmentRefs(nlohmann::json &node) {
+        if (node.is_object()) {
+            for (auto &[key, child] : node.items()) {
+                if (key == "$ref" && child.is_string()) {
+                    const std::string ref = child.get<std::string>();
+                    if (ref == "#") {
+                        child = std::string("#/") + kRootKey;
+                    } else if (ref.rfind("#/", 0) == 0) {
+                        child = std::string("#/") + kRootKey + "/" + ref.substr(2);
+                    }
+                    continue;
                 }
+                repointFragmentRefs(child);
             }
-            auto compiled = jsoncons::jsonschema::make_json_schema(
-                utils::jsonToOJson(standalone));
-            return compiled.is_valid(utils::jsonToOJson(value));
-        } catch (const std::exception &) {
-            // An uncompilable branch cannot be the one the value follows.
-            return false;
+        } else if (node.is_array()) {
+            for (auto &element : node) {
+                repointFragmentRefs(element);
+            }
         }
     }
 
     /**
-     * Unused legacy helper kept out of the walk; see subschemaMatches.
+     * A compiled schema that matches the subschema alone, with the root document still
+     * reachable so that references resolve, or null when it cannot be compiled.
+     *
+     * Compiling is far more expensive than validating, and the same branch is matched
+     * once per value the walk reaches, so the result is kept for the walk's lifetime.
+     */
+    std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>> matcherFor(
+        const nlohmann::json &subschema) const {
+        const std::string key = subschema.dump();
+        auto cached = matcher_cache.find(key);
+        if (cached != matcher_cache.end()) {
+            return cached->second;
+        }
+
+        std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::ojson>>
+            compiled;
+        try {
+            nlohmann::json standalone = subschema;
+            repointFragmentRefs(standalone);
+            standalone[kRootKey] = root;
+            repointFragmentRefs(standalone[kRootKey]);
+            // The dialect belongs to the document, not to the branch, and decides how
+            // the branch's own keywords are read.
+            auto schema_it = root.find("$schema");
+            if (schema_it != root.end() && !standalone.contains("$schema")) {
+                standalone["$schema"] = *schema_it;
+            }
+            compiled = std::make_shared<
+                jsoncons::jsonschema::json_schema<jsoncons::ojson>>(
+                jsoncons::jsonschema::make_json_schema(
+                    utils::jsonToOJson(standalone)));
+        } catch (const std::exception &) {
+            compiled = nullptr;
+        }
+        matcher_cache.emplace(key, compiled);
+        return compiled;
+    }
+
+    /**
+     * Whether the instance satisfies the subschema, used to pick the live branch of a
+     * oneOf/anyOf. Branches routinely share a JSON type and differ by const, required,
+     * ranges and so on, so the instance is validated against the whole subschema; a
+     * cheaper type comparison would evaluate rules from branches the value does not
+     * follow and reject valid messages.
+     *
+     * A branch that cannot be compiled falls back to comparing types rather than
+     * reporting no match: reporting no match would skip every rule in the branch the
+     * value actually follows, and skip it silently.
+     */
+    bool subschemaMatches(const nlohmann::json &subschema,
+                          const nlohmann::json &value) const {
+        auto compiled = matcherFor(subschema);
+        if (compiled == nullptr) {
+            return typeMatches(subschema, value);
+        }
+        try {
+            return compiled->is_valid(utils::jsonToOJson(value));
+        } catch (const std::exception &) {
+            return typeMatches(subschema, value);
+        }
+    }
+
+    /**
+     * A structural comparison of a schema's declared type against the instance. Used
+     * only when a branch cannot be compiled; see subschemaMatches.
      */
     static bool typeMatches(const nlohmann::json &schema,
                             const nlohmann::json &value) {

--- a/src/serdes/json/JsonValidate.cpp
+++ b/src/serdes/json/JsonValidate.cpp
@@ -1,0 +1,189 @@
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "schemaregistry/serdes/ValidationRule.h"
+#include "schemaregistry/serdes/json/JsonUtils.h"
+#include "schemaregistry/serdes/json/JsonValue.h"
+
+namespace schemaregistry::serdes::json::utils {
+
+namespace {
+
+struct Walker {
+    ValidationRuleExecutor &executor;
+    bool fail_fast;
+    std::vector<ValidationRuleError> &violations;
+    const nlohmann::json &root;
+
+    bool done() const { return fail_fast && !violations.empty(); }
+
+    /**
+     * Follow a local "$ref" ("#/definitions/Foo") to the schema it names.
+     * Non-local refs are left unresolved — the schema node is returned as-is.
+     */
+    const nlohmann::json *resolveRef(const nlohmann::json &schema) const {
+        if (!schema.is_object()) {
+            return &schema;
+        }
+        auto ref_it = schema.find("$ref");
+        if (ref_it == schema.end() || !ref_it->is_string()) {
+            return &schema;
+        }
+        std::string ref = ref_it->get<std::string>();
+        if (ref.empty() || ref[0] != '#') {
+            return &schema;
+        }
+        try {
+            return &root.at(nlohmann::json::json_pointer(ref.substr(1)));
+        } catch (const nlohmann::json::exception &) {
+            return &schema;
+        }
+    }
+
+    /**
+     * Evaluate the inline rules declared on schema against value. Skips null
+     * values, honoring the skip-on-null contract.
+     */
+    bool evaluateRules(const nlohmann::json &schema,
+                       const nlohmann::json &value, const std::string &path) {
+        if (value.is_null() || !schema.is_object()) {
+            return false;
+        }
+        auto rules_it = schema.find(VALIDATION_RULES_PROP);
+        if (rules_it == schema.end()) {
+            return false;
+        }
+        auto rules = parseValidationRules(*rules_it);
+        if (rules.empty()) {
+            return false;
+        }
+        auto serde_value = makeJsonValue(value);
+        for (const auto &rule : rules) {
+            evaluateValidationRule(executor, rule, *serde_value, path,
+                                   violations);
+            if (done()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the instance could plausibly be described by the subschema, used
+     * to pick the live branch of a oneOf/anyOf. Only the declared "type" is
+     * considered: a full validation would need a compiled validator per branch,
+     * and getting this wrong would attribute violations to a branch the value
+     * does not follow.
+     */
+    static bool typeMatches(const nlohmann::json &schema,
+                            const nlohmann::json &value) {
+        if (!schema.is_object()) {
+            return false;
+        }
+        auto type_it = schema.find("type");
+        if (type_it == schema.end()) {
+            // No declared type; a $ref or bare property set still describes an
+            // object.
+            return schema.contains("$ref") || schema.contains("properties")
+                       ? value.is_object()
+                       : false;
+        }
+        auto matches = [&value](const std::string &type) {
+            if (type == "object") return value.is_object();
+            if (type == "array") return value.is_array();
+            if (type == "string") return value.is_string();
+            if (type == "boolean") return value.is_boolean();
+            if (type == "null") return value.is_null();
+            if (type == "integer") return value.is_number_integer();
+            if (type == "number") return value.is_number();
+            return false;
+        };
+        if (type_it->is_string()) {
+            return matches(type_it->get<std::string>());
+        }
+        if (type_it->is_array()) {
+            for (const auto &type : *type_it) {
+                if (type.is_string() && matches(type.get<std::string>())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    void walk(const nlohmann::json &schema, const nlohmann::json &value,
+              const std::string &path);
+};
+
+void Walker::walk(const nlohmann::json &schema, const nlohmann::json &value,
+                  const std::string &path) {
+    if (done()) {
+        return;
+    }
+    const nlohmann::json &node = *resolveRef(schema);
+    if (!node.is_object()) {
+        return;
+    }
+
+    // Rules declared at this level: `this` is the value at this location.
+    if (evaluateRules(node, value, path)) {
+        return;
+    }
+
+    // allOf branches all apply; for oneOf/anyOf only the branches whose type
+    // matches the instance do.
+    for (const char *keyword : {"allOf", "oneOf", "anyOf"}) {
+        auto branches_it = node.find(keyword);
+        if (branches_it == node.end() || !branches_it->is_array()) {
+            continue;
+        }
+        bool all = std::string(keyword) == "allOf";
+        for (const auto &branch : *branches_it) {
+            if (all || typeMatches(*resolveRef(branch), value)) {
+                walk(branch, value, path);
+                if (done()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    auto properties_it = node.find("properties");
+    if (properties_it != node.end() && properties_it->is_object() &&
+        value.is_object()) {
+        for (const auto &[name, property_schema] : properties_it->items()) {
+            auto value_it = value.find(name);
+            if (value_it == value.end()) {
+                continue;
+            }
+            walk(property_schema, *value_it, appendValidationPath(path, name));
+            if (done()) {
+                return;
+            }
+        }
+    }
+
+    auto items_it = node.find("items");
+    if (items_it != node.end() && items_it->is_object() && value.is_array()) {
+        for (size_t i = 0; i < value.size(); ++i) {
+            walk(*items_it, value[i], path + "[" + std::to_string(i) + "]");
+            if (done()) {
+                return;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const nlohmann::json &schema,
+    const nlohmann::json &value, bool fail_fast) {
+    std::vector<ValidationRuleError> violations;
+    Walker walker{executor, fail_fast, violations, schema};
+    walker.walk(schema, value, "$");
+    return violations;
+}
+
+}  // namespace schemaregistry::serdes::json::utils

--- a/src/serdes/json/JsonValidate.cpp
+++ b/src/serdes/json/JsonValidate.cpp
@@ -233,15 +233,28 @@ void Walker::walk(const nlohmann::json &schema, const nlohmann::json &value,
     if (done()) {
         return;
     }
-    const nlohmann::json &node = *resolveRef(schema);
-    if (!node.is_object()) {
+    if (!schema.is_object()) {
         return;
     }
 
-    // Rules declared at this level: `this` is the value at this location.
-    if (evaluateRules(node, value, path)) {
+    // Rules declared at this level: `this` is the value at this location. This runs before
+    // the reference is followed, because a node carrying both "$ref" and "confluent:rules"
+    // declares rules of its own: the JVM client evaluates the referring node and then the
+    // schema it names, charging both, and every other client follows it.
+    if (evaluateRules(schema, value, path)) {
         return;
     }
+
+    const nlohmann::json *resolved = resolveRef(schema);
+    if (resolved != &schema) {
+        // Continue at the referenced schema, which the recursive call charges its own
+        // rules. A reference contributes nothing else: as in the JVM client, the keywords
+        // that decide the walk come from the schema it names, not from the node holding
+        // the reference.
+        walk(*resolved, value, path);
+        return;
+    }
+    const nlohmann::json &node = schema;
 
     // allOf branches all apply; for oneOf/anyOf only the branches whose type
     // matches the instance do.

--- a/src/serdes/json/JsonValidate.cpp
+++ b/src/serdes/json/JsonValidate.cpp
@@ -19,8 +19,12 @@ struct Walker {
     bool done() const { return fail_fast && !violations.empty(); }
 
     /**
-     * Follow a local "$ref" ("#/definitions/Foo") to the schema it names.
-     * Non-local refs are left unresolved — the schema node is returned as-is.
+     * Follow a "$ref" to the schema it names. References are flattened into
+     * local pointers before the walk, so a ref that cannot be followed means
+     * the schema is broken or refers somewhere we cannot see — which throws
+     * rather than being treated as a node carrying no rules, since silently
+     * skipping the referenced subtree would let a message serialize without the
+     * checks the reference was there to supply.
      */
     const nlohmann::json *resolveRef(const nlohmann::json &schema) const {
         if (!schema.is_object()) {
@@ -32,12 +36,14 @@ struct Walker {
         }
         std::string ref = ref_it->get<std::string>();
         if (ref.empty() || ref[0] != '#') {
-            return &schema;
+            throw JsonError("cannot resolve reference '" + ref +
+                            "' while validating inline rules");
         }
         try {
             return &root.at(nlohmann::json::json_pointer(ref.substr(1)));
-        } catch (const nlohmann::json::exception &) {
-            return &schema;
+        } catch (const nlohmann::json::exception &e) {
+            throw JsonError("cannot resolve reference '" + ref +
+                            "' while validating inline rules: " + e.what());
         }
     }
 

--- a/src/serdes/protobuf/ProtobufSerializer.cpp
+++ b/src/serdes/protobuf/ProtobufSerializer.cpp
@@ -44,9 +44,11 @@ ProtobufSerde::getParsedSchema(
     std::shared_ptr<schemaregistry::rest::ISchemaRegistryClient> client) {
     std::lock_guard<std::mutex> lock(cache_mutex_);
 
-    // Create cache key from schema content
     auto schema_str = schema.getSchema();
-    std::string cache_key = schema_str.value_or("");
+    // Keyed on the whole schema: the descriptor pool built below contains the
+    // referenced .proto files, so two roots with the same text but different
+    // references do not parse to the same thing.
+    std::string cache_key = schemaCacheKey(schema);
 
     auto it = parsed_schemas_cache_.find(cache_key);
     if (it != parsed_schemas_cache_.end()) {
@@ -67,7 +69,8 @@ ProtobufSerde::getParsedSchema(
     }
 
     // Parse main schema
-    auto file_desc = stringToSchema(pool.get(), "main.proto", cache_key);
+    auto file_desc =
+        stringToSchema(pool.get(), "main.proto", schema_str.value_or(""));
 
     // Store in cache with raw FileDescriptor pointer (owned by pool)
     parsed_schemas_cache_[cache_key] =

--- a/src/serdes/protobuf/ProtobufUtils.cpp
+++ b/src/serdes/protobuf/ProtobufUtils.cpp
@@ -129,6 +129,14 @@ ProtobufVariant transformRecursive(
             for (int i = 0; i < descriptor->field_count(); ++i) {
                 const google::protobuf::FieldDescriptor* fd =
                     descriptor->field(i);
+                if (fd == descriptor->map_key()) {
+                    // A map field arrives as a list of entry messages, so the walk
+                    // reaches the entry's key as well as its value. A key is part of
+                    // the map's identity rather than a value to transform - rewriting
+                    // it would move the entry - and the validation walk never
+                    // evaluates anything on it either.
+                    continue;
+                }
                 auto field = transformFieldWithContext(ctx, fd, descriptor,
                                                        result.get());
                 if (field.has_value()) {
@@ -223,9 +231,12 @@ std::optional<ProtobufVariant> transformFieldWithContext(
     ctx.enterField(*temp_serde_value, fd->full_name(), fd->name(),
                    getFieldType(fd), getInlineTags(fd));
 
-    if (fd->containing_oneof() &&
+    // Skip-on-null, as in the validation walk: a field with explicit presence that is
+    // unset has no value to transform, and writing one back would materialize it -
+    // turning an absent message or unset optional scalar into a present one carrying a
+    // transformed default. has_presence covers oneof members too.
+    if (fd->has_presence() &&
         !message->GetReflection()->HasField(*message, fd)) {
-        // Skip oneof fields that are not set
         ctx.exitField();
         return std::nullopt;
     }

--- a/src/serdes/protobuf/ProtobufUtils.cpp
+++ b/src/serdes/protobuf/ProtobufUtils.cpp
@@ -698,22 +698,63 @@ void setMessageField(google::protobuf::Message* message,
     }
 }
 
+namespace {
+
+// confluent.Meta is installed on every options message as extension field 1088.
+constexpr int kMetaExtensionNumber = 1088;
+
+// Recovers a Meta that the descriptor's pool left unresolved, by parsing it out of the
+// options' unknown fields.
+std::optional<confluent::Meta> parseMetaFromUnknownFields(
+    const google::protobuf::UnknownFieldSet& unknown) {
+    for (int i = 0; i < unknown.field_count(); ++i) {
+        const auto& field = unknown.field(i);
+        if (field.number() != kMetaExtensionNumber ||
+            field.type() !=
+                google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
+            continue;
+        }
+        confluent::Meta meta;
+        if (meta.ParseFromString(field.length_delimited())) {
+            return meta;
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+std::optional<confluent::Meta> getMessageMeta(
+    const google::protobuf::Descriptor* message_desc) {
+    if (!message_desc) {
+        return std::nullopt;
+    }
+    const google::protobuf::MessageOptions& options = message_desc->options();
+    if (options.HasExtension(confluent::message_meta)) {
+        return options.GetExtension(confluent::message_meta);
+    }
+    return parseMetaFromUnknownFields(options.unknown_fields());
+}
+
+std::optional<confluent::Meta> getFieldMeta(
+    const google::protobuf::FieldDescriptor* field_desc) {
+    if (!field_desc) {
+        return std::nullopt;
+    }
+    const google::protobuf::FieldOptions& options = field_desc->options();
+    if (options.HasExtension(confluent::field_meta)) {
+        return options.GetExtension(confluent::field_meta);
+    }
+    return parseMetaFromUnknownFields(options.unknown_fields());
+}
+
 std::unordered_set<std::string> getInlineTags(
     const google::protobuf::FieldDescriptor* field_desc) {
     std::unordered_set<std::string> tag_set;
 
-    if (!field_desc) {
-        return tag_set;
-    }
-
-    // Try to get the confluent.field_meta extension from the field options
-    const google::protobuf::FieldOptions& options = field_desc->options();
-
-    if (options.HasExtension(confluent::field_meta)) {
-        auto ext = options.GetExtension(confluent::field_meta);
-        const auto& tags =
-            ext.tags();  // Call tags() method to get RepeatedPtrField
-        for (const auto& tag : tags) {
+    auto meta = getFieldMeta(field_desc);
+    if (meta.has_value()) {
+        for (const auto& tag : meta->tags()) {
             tag_set.insert(tag);
         }
     }

--- a/src/serdes/protobuf/ProtobufUtils.cpp
+++ b/src/serdes/protobuf/ProtobufUtils.cpp
@@ -232,7 +232,17 @@ std::optional<ProtobufVariant> transformFieldWithContext(
 
     try {
         ProtobufVariant value = getMessageFieldValue(message, fd);
-        ProtobufVariant new_value = transformRecursive(ctx, desc, value);
+        // Descend with the field's own message type. Walking a nested message
+        // against the containing descriptor applies the parent's fields to the
+        // child, which the reflection API rejects outright. A map field arrives as
+        // a list of entry messages, so its message type - the entry type - is the
+        // right descriptor for those too.
+        const google::protobuf::Descriptor* child_desc = desc;
+        if (fd->type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE ||
+            fd->type() == google::protobuf::FieldDescriptor::TYPE_GROUP) {
+            child_desc = fd->message_type();
+        }
+        ProtobufVariant new_value = transformRecursive(ctx, child_desc, value);
 
         // Check for condition rules
         auto rule_kind = ctx.getRule().getKind();

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -1,0 +1,269 @@
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+
+#include <string>
+#include <vector>
+
+#include "confluent/meta.pb.h"
+#include "schemaregistry/serdes/ValidationRule.h"
+#include "schemaregistry/serdes/protobuf/ProtobufTypes.h"
+#include "schemaregistry/serdes/protobuf/ProtobufUtils.h"
+
+namespace schemaregistry::serdes::protobuf::utils {
+
+namespace {
+
+std::vector<ValidationRule> toValidationRules(const confluent::Meta &meta) {
+    std::vector<ValidationRule> rules;
+    rules.reserve(static_cast<size_t>(meta.rules_size()));
+    for (const auto &rule : meta.rules()) {
+        rules.push_back(
+            ValidationRule{rule.name(), rule.doc(), rule.expr(), rule.sql()});
+    }
+    return rules;
+}
+
+/**
+ * Render a map key the way the dotted path notation expects: string keys are
+ * quoted, everything else is rendered bare.
+ */
+std::string mapKeyToString(const google::protobuf::Message &entry,
+                           const google::protobuf::FieldDescriptor *key_field) {
+    const auto *reflection = entry.GetReflection();
+    switch (key_field->cpp_type()) {
+        case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+            return "\"" + reflection->GetString(entry, key_field) + "\"";
+        case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+            return reflection->GetBool(entry, key_field) ? "true" : "false";
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+            return std::to_string(reflection->GetInt32(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+            return std::to_string(reflection->GetInt64(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+            return std::to_string(reflection->GetUInt32(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+            return std::to_string(reflection->GetUInt64(entry, key_field));
+        default:
+            return "";
+    }
+}
+
+struct Walker {
+    ValidationRuleExecutor &executor;
+    bool fail_fast;
+    std::vector<ValidationRuleError> &violations;
+
+    bool done() const { return fail_fast && !violations.empty(); }
+
+    bool evaluateRules(const std::vector<ValidationRule> &rules,
+                       const SerdeValue &value, const std::string &path) {
+        for (const auto &rule : rules) {
+            evaluateValidationRule(executor, rule, value, path, violations);
+            if (done()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Wrap a single (non-repeated) field value so it can be handed to the
+     * executor as `this`.
+     */
+    static std::unique_ptr<SerdeValue> fieldValue(
+        const google::protobuf::Message &message,
+        const google::protobuf::FieldDescriptor *field, int index);
+
+    void walkMessage(const google::protobuf::Message &message,
+                     const std::string &path);
+};
+
+std::unique_ptr<SerdeValue> Walker::fieldValue(
+    const google::protobuf::Message &message,
+    const google::protobuf::FieldDescriptor *field, int index) {
+    const auto *reflection = message.GetReflection();
+    bool repeated = field->is_repeated();
+    switch (field->cpp_type()) {
+        case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedBool(message, field, index)
+                         : reflection->GetBool(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedInt32(message, field, index)
+                         : reflection->GetInt32(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedInt64(message, field, index)
+                         : reflection->GetInt64(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedUInt32(message, field, index)
+                         : reflection->GetUInt32(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedUInt64(message, field, index)
+                         : reflection->GetUInt64(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedFloat(message, field, index)
+                         : reflection->GetFloat(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+            return makeProtobufValue(ProtobufVariant(
+                repeated ? reflection->GetRepeatedDouble(message, field, index)
+                         : reflection->GetDouble(message, field)));
+        case google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
+            return makeProtobufValue(ProtobufVariant::createEnum(
+                repeated ? reflection->GetRepeatedEnum(message, field, index)
+                               ->number()
+                         : reflection->GetEnum(message, field)->number()));
+        case google::protobuf::FieldDescriptor::CPPTYPE_STRING: {
+            std::string scratch;
+            const std::string &value =
+                repeated
+                    ? reflection->GetRepeatedStringReference(message, field,
+                                                             index, &scratch)
+                    : reflection->GetStringReference(message, field, &scratch);
+            if (field->type() ==
+                google::protobuf::FieldDescriptor::TYPE_BYTES) {
+                return makeProtobufValue(ProtobufVariant(
+                    std::vector<uint8_t>(value.begin(), value.end())));
+            }
+            return makeProtobufValue(ProtobufVariant(value));
+        }
+        case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE: {
+            const auto &nested =
+                repeated ? reflection->GetRepeatedMessage(message, field, index)
+                         : reflection->GetMessage(message, field);
+            auto copy =
+                std::unique_ptr<google::protobuf::Message>(nested.New());
+            copy->CopyFrom(nested);
+            return makeProtobufValue(ProtobufVariant(std::move(copy)));
+        }
+        default:
+            return nullptr;
+    }
+}
+
+void Walker::walkMessage(const google::protobuf::Message &message,
+                         const std::string &path) {
+    if (done()) {
+        return;
+    }
+    const auto *descriptor = message.GetDescriptor();
+    const auto *reflection = message.GetReflection();
+    if (descriptor == nullptr || reflection == nullptr) {
+        return;
+    }
+
+    // Message-level rules: `this` is the message itself.
+    const auto &message_options = descriptor->options();
+    if (message_options.HasExtension(confluent::message_meta)) {
+        auto rules = toValidationRules(
+            message_options.GetExtension(confluent::message_meta));
+        if (!rules.empty()) {
+            auto copy =
+                std::unique_ptr<google::protobuf::Message>(message.New());
+            copy->CopyFrom(message);
+            auto value = makeProtobufValue(ProtobufVariant(std::move(copy)));
+            if (evaluateRules(rules, *value, path)) {
+                return;
+            }
+        }
+    }
+
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const auto *field = descriptor->field(i);
+        std::vector<ValidationRule> rules;
+        const auto &field_options = field->options();
+        if (field_options.HasExtension(confluent::field_meta)) {
+            rules = toValidationRules(
+                field_options.GetExtension(confluent::field_meta));
+        }
+        std::string field_path = appendValidationPath(path, field->name());
+
+        if (field->is_map()) {
+            const auto *entry = field->message_type();
+            const auto *key_field = entry->map_key();
+            const auto *value_field = entry->map_value();
+            int count = reflection->FieldSize(message, field);
+            for (int index = 0; index < count; ++index) {
+                const auto &map_entry =
+                    reflection->GetRepeatedMessage(message, field, index);
+                std::string entry_path = field_path + "[" +
+                                         mapKeyToString(map_entry, key_field) +
+                                         "]";
+                auto value = fieldValue(map_entry, value_field, 0);
+                if (value && evaluateRules(rules, *value, entry_path)) {
+                    return;
+                }
+                if (value_field->cpp_type() ==
+                    google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+                    walkMessage(map_entry.GetReflection()->GetMessage(
+                                    map_entry, value_field),
+                                entry_path);
+                    if (done()) {
+                        return;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (field->is_repeated()) {
+            int count = reflection->FieldSize(message, field);
+            for (int index = 0; index < count; ++index) {
+                std::string element_path =
+                    field_path + "[" + std::to_string(index) + "]";
+                auto value = fieldValue(message, field, index);
+                if (value && evaluateRules(rules, *value, element_path)) {
+                    return;
+                }
+                if (field->cpp_type() ==
+                    google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+                    walkMessage(
+                        reflection->GetRepeatedMessage(message, field, index),
+                        element_path);
+                    if (done()) {
+                        return;
+                    }
+                }
+            }
+            continue;
+        }
+
+        // Skip-on-null: an unset optional or oneof member does not have its
+        // rules invoked. Proto3 scalars without presence always report as set
+        // here, matching how the other clients treat a defaulted scalar.
+        if (field->has_presence() && !reflection->HasField(message, field)) {
+            continue;
+        }
+
+        if (!rules.empty()) {
+            auto value = fieldValue(message, field, 0);
+            if (value && evaluateRules(rules, *value, field_path)) {
+                return;
+            }
+        }
+        if (field->cpp_type() ==
+            google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            walkMessage(reflection->GetMessage(message, field), field_path);
+            if (done()) {
+                return;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+std::vector<ValidationRuleError> validateMessage(
+    ValidationRuleExecutor &executor, const google::protobuf::Message &message,
+    bool fail_fast) {
+    std::vector<ValidationRuleError> violations;
+    Walker walker{executor, fail_fast, violations};
+    walker.walkMessage(message, "");
+    return violations;
+}
+
+}  // namespace schemaregistry::serdes::protobuf::utils

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -9,6 +9,15 @@
 #include "schemaregistry/serdes/protobuf/ProtobufTypes.h"
 #include "schemaregistry/serdes/protobuf/ProtobufUtils.h"
 
+// Fix for Windows GetMessage macro conflict
+// On Windows, GetMessage is defined as a macro in winuser.h which conflicts
+// with the GetMessage method in google::protobuf::Reflection
+#ifdef _WIN32
+#ifdef GetMessage
+#undef GetMessage
+#endif
+#endif
+
 namespace schemaregistry::serdes::protobuf::utils {
 
 namespace {

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -579,12 +579,16 @@ std::vector<ValidationRuleError> validateMessage(
     std::string bytes;
     if (!message.SerializeToString(&bytes) ||
         !schema_message->ParseFromString(bytes)) {
-        // The message cannot be read through the registered schema. Walk it
-        // anyway, without the schema's view: every rule still runs, and one that
-        // depends on the schema's names fails as a rule error rather than
-        // silently not running at all.
-        walker.walkMessage(schema_descriptor, message, nullptr, "");
-        return violations;
+        // The bytes the producer is about to write cannot be read through the
+        // registered schema, so a consumer reading with that schema could not
+        // read them either - a bytes field carrying non-UTF-8 data against a
+        // schema that declares a string, for instance, which is a compatible
+        // change. Fail in the channel the caller already handles rather than
+        // reporting no violations and writing the record anyway, and name the
+        // type so it is searchable.
+        throw ProtobufError("Could not read message " +
+                            schema_descriptor->full_name() +
+                            " through the registered schema");
     }
     walker.walkMessage(schema_descriptor, message, schema_message.get(), "");
     return violations;

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -166,10 +166,9 @@ void Walker::walkMessage(const google::protobuf::Message &message,
     }
 
     // Message-level rules: `this` is the message itself.
-    const auto &message_options = descriptor->options();
-    if (message_options.HasExtension(confluent::message_meta)) {
-        auto rules = toValidationRules(
-            message_options.GetExtension(confluent::message_meta));
+    auto message_meta = getMessageMeta(descriptor);
+    if (message_meta.has_value()) {
+        auto rules = toValidationRules(*message_meta);
         if (!rules.empty()) {
             auto copy =
                 std::unique_ptr<google::protobuf::Message>(message.New());
@@ -184,10 +183,9 @@ void Walker::walkMessage(const google::protobuf::Message &message,
     for (int i = 0; i < descriptor->field_count(); ++i) {
         const auto *field = descriptor->field(i);
         std::vector<ValidationRule> rules;
-        const auto &field_options = field->options();
-        if (field_options.HasExtension(confluent::field_meta)) {
-            rules = toValidationRules(
-                field_options.GetExtension(confluent::field_meta));
+        auto field_meta = getFieldMeta(field);
+        if (field_meta.has_value()) {
+            rules = toValidationRules(*field_meta);
         }
         std::string field_path = appendValidationPath(path, field->name());
 

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -1,6 +1,8 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 
+#include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -57,6 +59,31 @@ std::string mapKeyToString(const google::protobuf::Message &entry,
     }
 }
 
+/**
+ * A map key as the variant a map value is keyed by, or nullopt for a key type
+ * protobuf cannot produce.
+ */
+std::optional<MapKey> mapKey(const google::protobuf::Message &entry,
+                             const google::protobuf::FieldDescriptor *key_field) {
+    const auto *reflection = entry.GetReflection();
+    switch (key_field->cpp_type()) {
+        case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+            return MapKey(reflection->GetString(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+            return MapKey(reflection->GetBool(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+            return MapKey(reflection->GetInt32(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+            return MapKey(reflection->GetInt64(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+            return MapKey(reflection->GetUInt32(entry, key_field));
+        case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+            return MapKey(reflection->GetUInt64(entry, key_field));
+        default:
+            return std::nullopt;
+    }
+}
+
 struct Walker {
     ValidationRuleExecutor &executor;
     bool fail_fast;
@@ -82,6 +109,21 @@ struct Walker {
     static std::unique_ptr<SerdeValue> fieldValue(
         const google::protobuf::Message &message,
         const google::protobuf::FieldDescriptor *field, int index);
+
+    /**
+     * A repeated field's elements as a single list value, so that a field-level
+     * rule sees the whole collection - `this` is the list, as in the JVM client.
+     */
+    static std::unique_ptr<SerdeValue> repeatedFieldValue(
+        const google::protobuf::Message &message,
+        const google::protobuf::FieldDescriptor *field);
+
+    /**
+     * A map field's entries as a single map value, for the same reason.
+     */
+    static std::unique_ptr<SerdeValue> mapFieldValue(
+        const google::protobuf::Message &message,
+        const google::protobuf::FieldDescriptor *field);
 
     void walkMessage(const google::protobuf::Message &message,
                      const std::string &path);
@@ -154,6 +196,46 @@ std::unique_ptr<SerdeValue> Walker::fieldValue(
     }
 }
 
+std::unique_ptr<SerdeValue> Walker::repeatedFieldValue(
+    const google::protobuf::Message &message,
+    const google::protobuf::FieldDescriptor *field) {
+    int count = message.GetReflection()->FieldSize(message, field);
+    std::vector<ProtobufVariant> elements;
+    elements.reserve(static_cast<size_t>(count));
+    for (int index = 0; index < count; ++index) {
+        auto element = fieldValue(message, field, index);
+        if (!element) {
+            return nullptr;
+        }
+        elements.push_back(asProtobuf(*element));
+    }
+    return makeProtobufValue(ProtobufVariant(std::move(elements)));
+}
+
+std::unique_ptr<SerdeValue> Walker::mapFieldValue(
+    const google::protobuf::Message &message,
+    const google::protobuf::FieldDescriptor *field) {
+    const auto *reflection = message.GetReflection();
+    const auto *entry_type = field->message_type();
+    const auto *key_field = entry_type->map_key();
+    const auto *value_field = entry_type->map_value();
+    int count = reflection->FieldSize(message, field);
+    std::map<MapKey, ProtobufVariant> entries;
+    for (int index = 0; index < count; ++index) {
+        const auto &entry = reflection->GetRepeatedMessage(message, field, index);
+        auto key = mapKey(entry, key_field);
+        if (!key.has_value()) {
+            return nullptr;
+        }
+        auto value = fieldValue(entry, value_field, 0);
+        if (!value) {
+            return nullptr;
+        }
+        entries.emplace(*key, asProtobuf(*value));
+    }
+    return makeProtobufValue(ProtobufVariant(std::move(entries)));
+}
+
 void Walker::walkMessage(const google::protobuf::Message &message,
                          const std::string &path) {
     if (done()) {
@@ -193,6 +275,16 @@ void Walker::walkMessage(const google::protobuf::Message &message,
             const auto *entry = field->message_type();
             const auto *key_field = entry->map_key();
             const auto *value_field = entry->map_value();
+            // Field-level rules see the whole map, matching the JVM client: `this`
+            // is the map itself, so a rule over its contents is written as a
+            // comprehension - this.all(k, this[k] >= 0) - rather than being
+            // invoked once per entry.
+            if (!rules.empty()) {
+                auto map_value = mapFieldValue(message, field);
+                if (map_value && evaluateRules(rules, *map_value, field_path)) {
+                    return;
+                }
+            }
             int count = reflection->FieldSize(message, field);
             for (int index = 0; index < count; ++index) {
                 const auto &map_entry =
@@ -200,10 +292,6 @@ void Walker::walkMessage(const google::protobuf::Message &message,
                 std::string entry_path = field_path + "[" +
                                          mapKeyToString(map_entry, key_field) +
                                          "]";
-                auto value = fieldValue(map_entry, value_field, 0);
-                if (value && evaluateRules(rules, *value, entry_path)) {
-                    return;
-                }
                 if (value_field->cpp_type() ==
                     google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
                     walkMessage(map_entry.GetReflection()->GetMessage(
@@ -218,14 +306,17 @@ void Walker::walkMessage(const google::protobuf::Message &message,
         }
 
         if (field->is_repeated()) {
+            // As for maps: the whole list is bound to `this`.
+            if (!rules.empty()) {
+                auto list_value = repeatedFieldValue(message, field);
+                if (list_value && evaluateRules(rules, *list_value, field_path)) {
+                    return;
+                }
+            }
             int count = reflection->FieldSize(message, field);
             for (int index = 0; index < count; ++index) {
                 std::string element_path =
                     field_path + "[" + std::to_string(index) + "]";
-                auto value = fieldValue(message, field, index);
-                if (value && evaluateRules(rules, *value, element_path)) {
-                    return;
-                }
                 if (field->cpp_type() ==
                     google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
                     walkMessage(

--- a/src/serdes/protobuf/ProtobufValidate.cpp
+++ b/src/serdes/protobuf/ProtobufValidate.cpp
@@ -1,9 +1,12 @@
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/dynamic_message.h>
 #include <google/protobuf/message.h>
 
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "confluent/meta.pb.h"
@@ -125,9 +128,47 @@ struct Walker {
         const google::protobuf::Message &message,
         const google::protobuf::FieldDescriptor *field);
 
-    void walkMessage(const google::protobuf::Message &message,
+    /**
+     * Walk `message` against `schema_descriptor`, the registered schema's view of
+     * its type.
+     *
+     * The walk is driven by `message`: it decides which fields exist, which are
+     * absent, and what the values are. Each field is paired to the schema by
+     * number - which is how protobuf identifies a field - and the schema's field
+     * supplies the rules and the name used in the reported path. Fields the
+     * schema does not declare are skipped, so the walk visits the intersection.
+     *
+     * `schema_message` is the same message re-read through `schema_descriptor`,
+     * or null when the two descriptors present it identically. Where it exists,
+     * it is what rules are handed: a rule's environment is built from the schema,
+     * so `this.renamed` cannot read a field the caller's type calls something
+     * else, and bytes and string are interchangeable at the same number without
+     * being interchangeable to a rule.
+     */
+    void walkMessage(const google::protobuf::Descriptor *schema_descriptor,
+                     const google::protobuf::Message &message,
+                     const google::protobuf::Message *schema_message,
                      const std::string &path);
 };
+
+/**
+ * The map entry in `entries` whose key matches `key`, or null. Map values pair by
+ * key rather than by position.
+ */
+const google::protobuf::Message *findMapEntry(
+    const google::protobuf::Message &owner,
+    const google::protobuf::FieldDescriptor *field, const std::string &key) {
+    const auto *reflection = owner.GetReflection();
+    const auto *key_field = field->message_type()->map_key();
+    int count = reflection->FieldSize(owner, field);
+    for (int i = 0; i < count; ++i) {
+        const auto &entry = reflection->GetRepeatedMessage(owner, field, i);
+        if (mapKeyToString(entry, key_field) == key) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
 
 std::unique_ptr<SerdeValue> Walker::fieldValue(
     const google::protobuf::Message &message,
@@ -236,25 +277,30 @@ std::unique_ptr<SerdeValue> Walker::mapFieldValue(
     return makeProtobufValue(ProtobufVariant(std::move(entries)));
 }
 
-void Walker::walkMessage(const google::protobuf::Message &message,
+void Walker::walkMessage(const google::protobuf::Descriptor *schema_descriptor,
+                         const google::protobuf::Message &message,
+                         const google::protobuf::Message *schema_message,
                          const std::string &path) {
     if (done()) {
         return;
     }
     const auto *descriptor = message.GetDescriptor();
     const auto *reflection = message.GetReflection();
-    if (descriptor == nullptr || reflection == nullptr) {
+    if (descriptor == nullptr || reflection == nullptr ||
+        schema_descriptor == nullptr) {
         return;
     }
 
-    // Message-level rules: `this` is the message itself.
-    auto message_meta = getMessageMeta(descriptor);
+    // Message-level rules: `this` is the message itself, read as the schema
+    // names it.
+    auto message_meta = getMessageMeta(schema_descriptor);
     if (message_meta.has_value()) {
         auto rules = toValidationRules(*message_meta);
         if (!rules.empty()) {
-            auto copy =
-                std::unique_ptr<google::protobuf::Message>(message.New());
-            copy->CopyFrom(message);
+            const auto &bound =
+                schema_message != nullptr ? *schema_message : message;
+            auto copy = std::unique_ptr<google::protobuf::Message>(bound.New());
+            copy->CopyFrom(bound);
             auto value = makeProtobufValue(ProtobufVariant(std::move(copy)));
             if (evaluateRules(rules, *value, path)) {
                 return;
@@ -264,23 +310,38 @@ void Walker::walkMessage(const google::protobuf::Message &message,
 
     for (int i = 0; i < descriptor->field_count(); ++i) {
         const auto *field = descriptor->field(i);
+        const auto *schema_field =
+            schema_descriptor->FindFieldByNumber(field->number());
+        if (schema_field == nullptr) {
+            // The registered schema does not declare this field, so it carries no
+            // rules and nothing below it can either.
+            continue;
+        }
         std::vector<ValidationRule> rules;
-        auto field_meta = getFieldMeta(field);
+        auto field_meta = getFieldMeta(schema_field);
         if (field_meta.has_value()) {
             rules = toValidationRules(*field_meta);
         }
-        std::string field_path = appendValidationPath(path, field->name());
+        // The path names the field as the registered schema does, which is what a
+        // rule refers to; the value is still read through the caller's field.
+        std::string field_path = appendValidationPath(path, schema_field->name());
+        // Where a schema view exists, values come from it, read through the
+        // schema's own field.
+        const google::protobuf::Message *value_owner =
+            schema_message != nullptr ? schema_message : &message;
+        const google::protobuf::FieldDescriptor *value_field =
+            schema_message != nullptr ? schema_field : field;
 
         if (field->is_map()) {
             const auto *entry = field->message_type();
             const auto *key_field = entry->map_key();
-            const auto *value_field = entry->map_value();
+            const auto *entry_value_field = entry->map_value();
             // Field-level rules see the whole map, matching the JVM client: `this`
             // is the map itself, so a rule over its contents is written as a
             // comprehension - this.all(k, this[k] >= 0) - rather than being
             // invoked once per entry.
             if (!rules.empty()) {
-                auto map_value = mapFieldValue(message, field);
+                auto map_value = mapFieldValue(*value_owner, value_field);
                 if (map_value && evaluateRules(rules, *map_value, field_path)) {
                     return;
                 }
@@ -289,17 +350,31 @@ void Walker::walkMessage(const google::protobuf::Message &message,
             for (int index = 0; index < count; ++index) {
                 const auto &map_entry =
                     reflection->GetRepeatedMessage(message, field, index);
-                std::string entry_path = field_path + "[" +
-                                         mapKeyToString(map_entry, key_field) +
-                                         "]";
-                if (value_field->cpp_type() ==
+                std::string key = mapKeyToString(map_entry, key_field);
+                std::string entry_path = field_path + "[" + key + "]";
+                if (entry_value_field->cpp_type() !=
                     google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
-                    walkMessage(map_entry.GetReflection()->GetMessage(
-                                    map_entry, value_field),
-                                entry_path);
-                    if (done()) {
-                        return;
+                    continue;
+                }
+                const auto *schema_entry_value = static_cast<
+                    const google::protobuf::Message *>(nullptr);
+                if (schema_message != nullptr) {
+                    const auto *schema_entry =
+                        findMapEntry(*schema_message, schema_field, key);
+                    if (schema_entry != nullptr) {
+                        schema_entry_value = &schema_entry->GetReflection()
+                                                  ->GetMessage(
+                                                      *schema_entry,
+                                                      schema_field->message_type()
+                                                          ->map_value());
                     }
+                }
+                walkMessage(schema_field->message_type()->map_value()->message_type(),
+                            map_entry.GetReflection()->GetMessage(
+                                map_entry, entry_value_field),
+                            schema_entry_value, entry_path);
+                if (done()) {
+                    return;
                 }
             }
             continue;
@@ -308,7 +383,7 @@ void Walker::walkMessage(const google::protobuf::Message &message,
         if (field->is_repeated()) {
             // As for maps: the whole list is bound to `this`.
             if (!rules.empty()) {
-                auto list_value = repeatedFieldValue(message, field);
+                auto list_value = repeatedFieldValue(*value_owner, value_field);
                 if (list_value && evaluateRules(rules, *list_value, field_path)) {
                     return;
                 }
@@ -317,14 +392,29 @@ void Walker::walkMessage(const google::protobuf::Message &message,
             for (int index = 0; index < count; ++index) {
                 std::string element_path =
                     field_path + "[" + std::to_string(index) + "]";
-                if (field->cpp_type() ==
-                    google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
-                    walkMessage(
-                        reflection->GetRepeatedMessage(message, field, index),
-                        element_path);
-                    if (done()) {
-                        return;
-                    }
+                if (field->cpp_type() !=
+                        google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE ||
+                    schema_field->cpp_type() !=
+                        google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+                    continue;
+                }
+                // Both lists came from the same bytes, so they line up; the guard
+                // is for safety.
+                const auto *schema_element = static_cast<
+                    const google::protobuf::Message *>(nullptr);
+                if (schema_message != nullptr &&
+                    index < schema_message->GetReflection()->FieldSize(
+                                *schema_message, schema_field)) {
+                    schema_element =
+                        &schema_message->GetReflection()->GetRepeatedMessage(
+                            *schema_message, schema_field, index);
+                }
+                walkMessage(
+                    schema_field->message_type(),
+                    reflection->GetRepeatedMessage(message, field, index),
+                    schema_element, element_path);
+                if (done()) {
+                    return;
                 }
             }
             continue;
@@ -333,19 +423,34 @@ void Walker::walkMessage(const google::protobuf::Message &message,
         // Skip-on-null: an unset optional or oneof member does not have its
         // rules invoked. Proto3 scalars without presence always report as set
         // here, matching how the other clients treat a defaulted scalar.
+        //
+        // Both halves are read from the caller's message: whether an unset field
+        // counts as absent is decided by the type that wrote it, not by the
+        // registered schema, and the two can disagree - moving a field into or
+        // out of a oneof is a compatible change.
         if (field->has_presence() && !reflection->HasField(message, field)) {
             continue;
         }
 
         if (!rules.empty()) {
-            auto value = fieldValue(message, field, 0);
+            auto value = fieldValue(*value_owner, value_field, 0);
             if (value && evaluateRules(rules, *value, field_path)) {
                 return;
             }
         }
         if (field->cpp_type() ==
-            google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
-            walkMessage(reflection->GetMessage(message, field), field_path);
+                google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE &&
+            schema_field->cpp_type() ==
+                google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            const auto *schema_nested = static_cast<
+                const google::protobuf::Message *>(nullptr);
+            if (schema_message != nullptr) {
+                schema_nested = &schema_message->GetReflection()->GetMessage(
+                    *schema_message, schema_field);
+            }
+            walkMessage(schema_field->message_type(),
+                        reflection->GetMessage(message, field), schema_nested,
+                        field_path);
             if (done()) {
                 return;
             }
@@ -353,14 +458,135 @@ void Walker::walkMessage(const google::protobuf::Message &message,
     }
 }
 
+/**
+ * Whether the two descriptors present every field they share - paired by number,
+ * which is how protobuf identifies a field - under the same name, type and label,
+ * recursively through message-valued fields.
+ *
+ * A field the registered schema declares and the caller's type does not counts as
+ * a difference: adding a field is a compatible change, and a message-level rule
+ * may reference the added field expecting the schema's default for it, which only
+ * a message read through the schema can supply. Fields only the caller declares
+ * are ignored - no rule can name them, and the walk skips them.
+ *
+ * `visited` holds the descriptor pairs already compared, so a self-referential
+ * message type terminates.
+ */
+bool presentsSameValues(
+    const google::protobuf::Descriptor *schema_descriptor,
+    const google::protobuf::Descriptor *runtime_descriptor,
+    std::set<std::pair<const google::protobuf::Descriptor *,
+                       const google::protobuf::Descriptor *>> &visited) {
+    if (!visited.emplace(schema_descriptor, runtime_descriptor).second) {
+        // Already compared on another path, or cycling back to it. Either way
+        // this pair contributes no new disagreement.
+        return true;
+    }
+    for (int i = 0; i < schema_descriptor->field_count(); ++i) {
+        const auto *schema_field = schema_descriptor->field(i);
+        if (runtime_descriptor->FindFieldByNumber(schema_field->number()) ==
+            nullptr) {
+            return false;
+        }
+    }
+    for (int i = 0; i < runtime_descriptor->field_count(); ++i) {
+        const auto *runtime_field = runtime_descriptor->field(i);
+        const auto *schema_field =
+            schema_descriptor->FindFieldByNumber(runtime_field->number());
+        if (schema_field == nullptr) {
+            continue;
+        }
+        if (schema_field->name() != runtime_field->name() ||
+            schema_field->type() != runtime_field->type() ||
+            schema_field->is_repeated() != runtime_field->is_repeated()) {
+            return false;
+        }
+        if (schema_field->cpp_type() ==
+                google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE &&
+            runtime_field->cpp_type() ==
+                google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE &&
+            !presentsSameValues(schema_field->message_type(),
+                                runtime_field->message_type(), visited)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Whether a message whose descriptor is `runtime_descriptor` has to be re-read
+ * through `schema_descriptor` before rules can bind `this` to it.
+ *
+ * Presence deliberately does not count. Whether an unset field is absent is
+ * decided by the producer's field on the producer's message, which the walk reads
+ * directly, so a schema that only moved a field into or out of a oneof needs no
+ * re-read.
+ *
+ * A field the schema declares and the caller's type does not does count, which
+ * means a type running behind the registered schema - the use.latest.version case
+ * - re-reads every record. Only an exact match skips the re-read. Narrowing that
+ * to the rules that could actually observe the added field is possible but not
+ * simple: a rule binding `this` at any ancestor can traverse into the field, and a
+ * field-level rule on a message-valued field binds `this` to a type that need not
+ * declare rules of its own, so a per-descriptor test for message-level rules would
+ * be wrong in both directions.
+ *
+ * Deliberately not memoized, unlike the other clients. A cache would have to be
+ * keyed by descriptor pointers, which carry no ownership: the pools that own them
+ * are held elsewhere and can be released, and a later pool allocated at the same
+ * address would then read the previous one's answer. The comparison itself is a
+ * bounded walk over the schema's own shape - no allocation, and skipped outright
+ * when the two descriptors are the same object, which is the usual case - against
+ * the serialize-and-parse it decides about.
+ */
+bool needsSchemaView(const google::protobuf::Descriptor *schema_descriptor,
+                     const google::protobuf::Descriptor *runtime_descriptor) {
+    if (schema_descriptor == runtime_descriptor) {
+        return false;
+    }
+    std::set<std::pair<const google::protobuf::Descriptor *,
+                       const google::protobuf::Descriptor *>>
+        visited;
+    bool needed = !presentsSameValues(schema_descriptor, runtime_descriptor, visited);
+    return needed;
+}
+
 }  // namespace
 
 std::vector<ValidationRuleError> validateMessage(
     ValidationRuleExecutor &executor, const google::protobuf::Message &message,
-    bool fail_fast) {
+    const google::protobuf::Descriptor *schema_descriptor, bool fail_fast) {
     std::vector<ValidationRuleError> violations;
+    const auto *runtime_descriptor = message.GetDescriptor();
+    if (schema_descriptor == nullptr) {
+        schema_descriptor = runtime_descriptor;
+    }
     Walker walker{executor, fail_fast, violations};
-    walker.walkMessage(message, "");
+    if (!needsSchemaView(schema_descriptor, runtime_descriptor)) {
+        walker.walkMessage(schema_descriptor, message, nullptr, "");
+        return violations;
+    }
+
+    // A rule that binds `this` to a message needs it in the schema's terms: a
+    // rule's environment is built from the registered schema, so `this.renamed`
+    // cannot read a field the caller's type calls something else. The two
+    // descriptors live in different pools, so round-trip through the wire format
+    // rather than CopyFrom - protobuf pairs fields by number there, which is what
+    // carries the values across a rename.
+    google::protobuf::DynamicMessageFactory factory;
+    auto schema_message = std::unique_ptr<google::protobuf::Message>(
+        factory.GetPrototype(schema_descriptor)->New());
+    std::string bytes;
+    if (!message.SerializeToString(&bytes) ||
+        !schema_message->ParseFromString(bytes)) {
+        // The message cannot be read through the registered schema. Walk it
+        // anyway, without the schema's view: every rule still runs, and one that
+        // depends on the schema's names fails as a rule error rather than
+        // silently not running at all.
+        walker.walkMessage(schema_descriptor, message, nullptr, "");
+        return violations;
+    }
+    walker.walkMessage(schema_descriptor, message, schema_message.get(), "");
     return violations;
 }
 

--- a/test/AvroTest.cpp
+++ b/test/AvroTest.cpp
@@ -480,6 +480,113 @@ TEST(AvroTest, CelFieldTransformation) {
     EXPECT_EQ(bytes_field[2], 3);
 }
 
+// A union-typed field goes through the union arm of the transform walk, which the scalar
+// fields above never reach. Two branches share the record type here, so the branch has to
+// be taken from the datum rather than guessed from its Avro type: walking the value against
+// the other branch's schema would name its field "x" and the rule would not fire.
+TEST(AvroTest, CelFieldTransformationOverUnion) {
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    auto client = SchemaRegistryClient::newClient(client_config);
+
+    auto ser_config = SerializerConfig(
+        false,  // auto_register_schemas
+        std::make_optional(SchemaSelector::useLatestVersion()),  // use_schema
+        true,   // normalize_schemas
+        false,  // validate
+        std::unordered_map<std::string, std::string>{}  // rule_config
+    );
+    auto deser_config = DeserializerConfig::createDefault();
+
+    const std::string schema_str = R"({
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {"name": "note", "type": ["null", "string"]},
+            {"name": "choice", "type": [
+                {"type": "record", "name": "Rec", "namespace": "a",
+                 "fields": [{"name": "x", "type": "string"}]},
+                {"type": "record", "name": "Rec", "namespace": "b",
+                 "fields": [{"name": "y", "type": "string"}]}
+            ]}
+        ]
+    })";
+
+    Rule cel_rule;
+    cel_rule.setName(std::make_optional<std::string>("test-cel"));
+    cel_rule.setKind(std::make_optional<Kind>(Kind::Transform));
+    cel_rule.setMode(std::make_optional<Mode>(Mode::Write));
+    cel_rule.setType(std::make_optional<std::string>("CEL_FIELD"));
+    cel_rule.setExpr(std::make_optional<std::string>(
+        "name == 'note' || name == 'y' ; value + '-suffix'"));
+
+    RuleSet rule_set;
+    std::vector<Rule> domain_rules = {cel_rule};
+    rule_set.setDomainRules(std::make_optional<std::vector<Rule>>(domain_rules));
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("AVRO"));
+    schema.setSchema(std::make_optional<std::string>(schema_str));
+    schema.setRuleSet(std::make_optional<RuleSet>(rule_set));
+    client->registerSchema("test-value", schema, false);
+
+    ::avro::ValidSchema avro_schema =
+        AvroSerializer::compileJsonSchema(schema_str);
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(std::make_shared<CelFieldExecutor>());
+    AvroSerializer serializer(client, std::nullopt, rule_registry, ser_config);
+    AvroDeserializer deserializer(client, rule_registry, deser_config);
+
+    SerializationContext ser_ctx;
+    ser_ctx.topic = "test";
+    ser_ctx.serde_type = SerdeType::Value;
+    ser_ctx.serde_format = SerdeFormat::Avro;
+
+    // The second branch of each union: a string note, and the record whose field the rule
+    // names.
+    ::avro::GenericDatum datum(avro_schema);
+    auto &record = datum.value<::avro::GenericRecord>();
+    auto &note = record.fieldAt(0);
+    note.selectBranch(1);
+    note.value<std::string>() = "hi";
+    auto &choice = record.fieldAt(1);
+    choice.selectBranch(1);
+    choice.value<::avro::GenericRecord>().setFieldAt(
+        0, ::avro::GenericDatum(std::string("there")));
+
+    auto round_tripped =
+        deserializer.deserialize(ser_ctx, serializer.serialize(ser_ctx, datum));
+    ASSERT_TRUE(round_tripped.value.type() == ::avro::AVRO_RECORD);
+    auto &result = round_tripped.value.value<::avro::GenericRecord>();
+
+    EXPECT_EQ(result.fieldAt(0).value<std::string>(), "hi-suffix");
+    // The branch is preserved, and it is the one the rule applied to.
+    ASSERT_TRUE(result.fieldAt(1).isUnion());
+    EXPECT_EQ(result.fieldAt(1).unionBranch(), 1u);
+    EXPECT_EQ(result.fieldAt(1).value<::avro::GenericRecord>()
+                  .fieldAt(0)
+                  .value<std::string>(),
+              "there-suffix");
+
+    // The null branch of a nullable field is left alone rather than transformed.
+    ::avro::GenericDatum without_note(avro_schema);
+    auto &bare = without_note.value<::avro::GenericRecord>();
+    auto &bare_choice = bare.fieldAt(1);
+    bare_choice.selectBranch(1);
+    bare_choice.value<::avro::GenericRecord>().setFieldAt(
+        0, ::avro::GenericDatum(std::string("only")));
+
+    auto bare_result = deserializer.deserialize(
+        ser_ctx, serializer.serialize(ser_ctx, without_note));
+    auto &bare_out = bare_result.value.value<::avro::GenericRecord>();
+    EXPECT_EQ(bare_out.fieldAt(0).type(), ::avro::AVRO_NULL);
+    EXPECT_EQ(bare_out.fieldAt(1).value<::avro::GenericRecord>()
+                  .fieldAt(0)
+                  .value<std::string>(),
+              "only-suffix");
+}
+
 TEST(AvroTest, JsonataWithCelField) {
     // JSONATA rule to transform "size" field to "height" field
     const std::string rule1_to_2 = 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SOURCES
 
 if(SCHEMAREGISTRY_WITH_RULES)
     list(APPEND TEST_SOURCES AzureKmsAeadTest.cpp)  # Azure KMS AEAD wire-format tests
+    list(APPEND TEST_SOURCES ValidationRuleTest.cpp)  # Inline validation rule tests
 endif()
 
 if(SCHEMAREGISTRY_WITH_AVRO)

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1000,3 +1000,112 @@ TEST(ValidationRuleTest, ProtobufCollectionRulesSeeTheWholeCollection) {
     EXPECT_EQ(map_violations[0].field_path, "scores");
     EXPECT_TRUE(map_violations[0].cause.empty());
 }
+
+// A field with explicit presence that is unset has nothing to transform, and writing a
+// value back would materialize it: an absent message would become present, carrying a
+// transformed default.
+TEST(ValidationRuleTest, ProtobufFieldTransformLeavesAbsentFieldsAbsent) {
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    auto client = std::make_shared<MockSchemaRegistryClient>(client_config);
+
+    std::unordered_map<std::string, std::string> rule_config;
+    auto ser_conf = SerializerConfig(
+        false, std::make_optional(SchemaSelector::useLatestVersion()), false,
+        false, rule_config);
+
+    // address is absent.
+    test::ValidationOrder obj;
+    obj.set_id("ord-1234");
+    obj.set_quantity(2);
+    obj.add_items("a");
+    obj.set_serial(1);
+
+    Rule rule;
+    rule.setName("test-cel");
+    rule.setKind(Kind::Transform);
+    rule.setMode(Mode::Write);
+    rule.setType("CEL_FIELD");
+    rule.setExpr("typeName == 'STRING' ; value + '-suffix'");
+    RuleSet rule_set;
+    rule_set.setDomainRules(std::vector<Rule>{rule});
+
+    Schema schema;
+    schema.setSchemaType("PROTOBUF");
+    schema.setRuleSet(rule_set);
+    schema.setSchema(
+        protobuf::utils::schemaToString(obj.GetDescriptor()->file()));
+    client->registerSchema("test-value", schema, false);
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(
+        std::make_shared<schemaregistry::rules::cel::CelFieldExecutor>());
+
+    schemaregistry::serdes::protobuf::ProtobufSerializer<test::ValidationOrder>
+        ser(client, std::nullopt, rule_registry, ser_conf);
+    auto ctx = valueContext(SerdeFormat::Protobuf);
+    auto bytes = ser.serialize(ctx, obj);
+
+    schemaregistry::serdes::protobuf::ProtobufDeserializer<test::ValidationOrder>
+        deser(client, rule_registry, DeserializerConfig::createDefault());
+    auto result = deser.deserialize(ctx, bytes);
+    const auto *order = dynamic_cast<const test::ValidationOrder *>(result.get());
+    ASSERT_NE(order, nullptr);
+    EXPECT_FALSE(order->has_address()) << "the absent message was materialized";
+    // The fields that are present are still transformed.
+    EXPECT_EQ(order->id(), "ord-1234-suffix");
+}
+
+// A map field arrives as a list of entry messages, so the transform walk reaches the
+// entry's key as well as its value. A key is part of the map's identity rather than a
+// value to transform - rewriting it moves the entry - and the validation walk never
+// evaluates anything on a key either.
+TEST(ValidationRuleTest, ProtobufFieldTransformLeavesMapKeysAlone) {
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    auto client = std::make_shared<MockSchemaRegistryClient>(client_config);
+
+    std::unordered_map<std::string, std::string> rule_config;
+    auto ser_conf = SerializerConfig(
+        false, std::make_optional(SchemaSelector::useLatestVersion()), false,
+        false, rule_config);
+
+    test::ValidationOrder obj = protoOrder("ord-1234", 2, {"a"}, "12345");
+    (*obj.mutable_scores())["k1"] = 1;
+
+    Rule rule;
+    rule.setName("test-cel");
+    rule.setKind(Kind::Transform);
+    rule.setMode(Mode::Write);
+    rule.setType("CEL_FIELD");
+    rule.setExpr("typeName == 'STRING' ; value + '-suffix'");
+    RuleSet rule_set;
+    rule_set.setDomainRules(std::vector<Rule>{rule});
+
+    Schema schema;
+    schema.setSchemaType("PROTOBUF");
+    schema.setRuleSet(rule_set);
+    schema.setSchema(
+        protobuf::utils::schemaToString(obj.GetDescriptor()->file()));
+    client->registerSchema("test-value", schema, false);
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(
+        std::make_shared<schemaregistry::rules::cel::CelFieldExecutor>());
+
+    schemaregistry::serdes::protobuf::ProtobufSerializer<test::ValidationOrder>
+        ser(client, std::nullopt, rule_registry, ser_conf);
+    auto ctx = valueContext(SerdeFormat::Protobuf);
+    auto bytes = ser.serialize(ctx, obj);
+
+    schemaregistry::serdes::protobuf::ProtobufDeserializer<test::ValidationOrder>
+        deser(client, rule_registry, DeserializerConfig::createDefault());
+    auto result = deser.deserialize(ctx, bytes);
+    const auto *order = dynamic_cast<const test::ValidationOrder *>(result.get());
+    ASSERT_NE(order, nullptr);
+    ASSERT_EQ(order->scores().size(), 1);
+    EXPECT_EQ(order->scores().begin()->first, "k1")
+        << "the map key was rewritten by the transform";
+    // The string fields that are values are still transformed.
+    EXPECT_EQ(order->id(), "ord-1234-suffix");
+}

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1016,6 +1016,28 @@ TEST(ValidationRuleTest, MessageLevelRulesSeeUnsignedFieldsAndMaps) {
     EXPECT_EQ(failures[0].rule.name, "sees_serial_and_scores");
 }
 
+// A map key is the one value whose type comes from the key field rather than from the
+// value itself, and CEL has a distinct unsigned type. Narrowed to int64, a uint64 key
+// above int64 max reads as negative, and a rule can neither compare it nor index by it.
+TEST(ValidationRuleTest, ProtobufPreservesUnsignedMapKeys) {
+    test::ValidationUnsignedKeys keys;
+    (*keys.mutable_by_serial())[std::numeric_limits<uint64_t>::max()] = 1;
+    auto violations = validateProto(keys);
+    for (const auto &violation : violations) {
+        EXPECT_TRUE(violation.cause.empty())
+            << "rule failed to evaluate: " << violation.toString();
+    }
+    EXPECT_EQ(violations.size(), 0u);
+
+    // and the rule really does run: a zero key fails it
+    test::ValidationUnsignedKeys zero;
+    (*zero.mutable_by_serial())[0] = 1;
+    auto failures = validateProto(zero);
+    ASSERT_EQ(failures.size(), 1u);
+    EXPECT_EQ(failures[0].rule.name, "keys_positive");
+    EXPECT_TRUE(failures[0].cause.empty());
+}
+
 
 // A rule that binds `this` to a nested message needs that message in the schema's
 // terms, not just the top-level one: a rule's environment is built from the
@@ -1083,6 +1105,43 @@ TEST(ValidationRuleTest, ProtobufMessageRuleSeesAFieldOnlyTheSchemaDeclares) {
         validator, order, schema_descriptor, false);
 
     EXPECT_TRUE(violations.empty()) << violations.size() << " violations";
+}
+
+// A message that cannot be read through the registered schema is refused, rather than
+// validated without the schema's view. The producer is about to write bytes a consumer
+// using that schema could not read, so reporting no violations would let exactly the
+// record nobody can consume through - which is what the JVM, Go, Rust, JS and Python
+// clients all treat as a serialization error. Non-UTF-8 data in a string field is the
+// reachable case: those same bytes are legal in the bytes field the schema may have been
+// widened from, and widening bytes to string is a compatible change.
+TEST(ValidationRuleTest, ProtobufRefusesAMessageTheSchemaCannotRead) {
+    google::protobuf::DescriptorPool pool;
+    const auto *schema_descriptor = rebuiltValidationDescriptor(
+        pool, [](google::protobuf::FileDescriptorProto &proto) {
+            // Any disagreement forces the re-read; a rename is the cheapest one.
+            auto *address = messageOf(proto, "ValidationAddress");
+            ASSERT_NE(address, nullptr);
+            for (auto &field : *address->mutable_field()) {
+                if (field.number() == 1) {
+                    field.set_name("renamed_zip");
+                    field.set_json_name("renamedZip");
+                }
+            }
+        });
+    ASSERT_NE(schema_descriptor, nullptr);
+
+    auto order = protoOrder("ord-1234", 1, {"a"}, "12345");
+    order.set_id(std::string("ord-\xff\xfe"));
+    CelValidator validator;
+    EXPECT_THROW(schemaregistry::serdes::protobuf::utils::validateMessage(
+                     validator, order, schema_descriptor, false),
+                 schemaregistry::serdes::protobuf::ProtobufError);
+
+    // The same schema reads a message that is valid under it, so the refusal is about
+    // the bytes and not about the rename.
+    auto readable = protoOrder("ord-1234", 1, {"a"}, "12345");
+    EXPECT_NO_THROW(schemaregistry::serdes::protobuf::utils::validateMessage(
+        validator, readable, schema_descriptor, false));
 }
 
 // A field-level rule on a repeated or map field is evaluated once, with the whole

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <limits>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -725,11 +726,58 @@ test::ValidationOrder protoOrder(const std::string &id, int32_t quantity,
     return order;
 }
 
+/**
+ * Rebuilds the validation proto's file into `pool`, with `mutate` applied to the
+ * copy, so a test can pair a registered schema against the generated type the way
+ * use.latest.version does. Returns the rebuilt ValidationOrder descriptor, which is
+ * a different object from the generated one even where it describes the same fields.
+ */
+const google::protobuf::Descriptor *rebuiltValidationDescriptor(
+    google::protobuf::DescriptorPool &pool,
+    const std::function<void(google::protobuf::FileDescriptorProto &)> &mutate) {
+    const auto *file = test::ValidationOrder::descriptor()->file();
+    // Dependencies first, so the file's imports resolve in the new pool.
+    std::function<void(const google::protobuf::FileDescriptor *)> add_dependency =
+        [&](const google::protobuf::FileDescriptor *dependency) {
+            for (int i = 0; i < dependency->dependency_count(); ++i) {
+                add_dependency(dependency->dependency(i));
+            }
+            if (pool.FindFileByName(dependency->name()) != nullptr) {
+                return;
+            }
+            google::protobuf::FileDescriptorProto proto;
+            dependency->CopyTo(&proto);
+            pool.BuildFile(proto);
+        };
+    for (int i = 0; i < file->dependency_count(); ++i) {
+        add_dependency(file->dependency(i));
+    }
+    google::protobuf::FileDescriptorProto proto;
+    file->CopyTo(&proto);
+    mutate(proto);
+    if (pool.BuildFile(proto) == nullptr) {
+        return nullptr;
+    }
+    return pool.FindMessageTypeByName("test.ValidationOrder");
+}
+
+google::protobuf::DescriptorProto *messageOf(
+    google::protobuf::FileDescriptorProto &proto, const std::string &name) {
+    for (auto &message : *proto.mutable_message_type()) {
+        if (message.name() == name) {
+            return &message;
+        }
+    }
+    return nullptr;
+}
+
 std::vector<ValidationRuleError> validateProto(
     const google::protobuf::Message &message, bool fail_fast = false) {
     CelValidator validator;
+    // The message is already in the schema's terms here, so its own descriptor is
+    // what carries the rules.
     return schemaregistry::serdes::protobuf::utils::validateMessage(
-        validator, message, fail_fast);
+        validator, message, message.GetDescriptor(), fail_fast);
 }
 
 }  // namespace
@@ -965,6 +1013,75 @@ TEST(ValidationRuleTest, MessageLevelRulesSeeUnsignedFieldsAndMaps) {
     auto failures = validateProto(message);
     ASSERT_EQ(failures.size(), 1u);
     EXPECT_EQ(failures[0].rule.name, "sees_serial_and_scores");
+}
+
+
+// A rule that binds `this` to a nested message needs that message in the schema's
+// terms, not just the top-level one: a rule's environment is built from the
+// registered schema, so `this.renamed_zip` cannot read a field the caller's type
+// calls `zip`. Renaming a field at the same number is a compatible change.
+TEST(ValidationRuleTest, ProtobufNestedMessageRuleSeesSchemaNamesUnderARename) {
+    google::protobuf::DescriptorPool pool;
+    const auto *schema_descriptor = rebuiltValidationDescriptor(
+        pool, [](google::protobuf::FileDescriptorProto &proto) {
+            auto *address = messageOf(proto, "ValidationAddress");
+            ASSERT_NE(address, nullptr);
+            for (auto &field : *address->mutable_field()) {
+                if (field.number() == 1) {
+                    field.set_name("renamed_zip");
+                    field.set_json_name("renamedZip");
+                    field.clear_options();
+                }
+            }
+            auto *meta = address->mutable_options()->MutableExtension(
+                confluent::message_meta);
+            meta->clear_rules();
+            auto *rule = meta->add_rules();
+            rule->set_name("zip_present");
+            rule->set_expr("size(this.renamed_zip) > 0");
+        });
+    ASSERT_NE(schema_descriptor, nullptr);
+
+    auto order = protoOrder("ord-1234", 1, {"a"}, "12345");
+    CelValidator validator;
+    auto violations = schemaregistry::serdes::protobuf::utils::validateMessage(
+        validator, order, schema_descriptor, false);
+
+    EXPECT_TRUE(violations.empty()) << violations.size() << " violations";
+}
+
+// Adding a field is the most ordinary compatible change there is, so the registered
+// schema can declare one the generated type has never heard of - and a
+// message-level rule can reference it, expecting the schema's default. That only
+// works if the message is read through the schema, so a field with no counterpart
+// is itself a reason to re-read, even when every shared field agrees.
+TEST(ValidationRuleTest, ProtobufMessageRuleSeesAFieldOnlyTheSchemaDeclares) {
+    google::protobuf::DescriptorPool pool;
+    const auto *schema_descriptor = rebuiltValidationDescriptor(
+        pool, [](google::protobuf::FileDescriptorProto &proto) {
+            auto *order = messageOf(proto, "ValidationOrder");
+            ASSERT_NE(order, nullptr);
+            auto *added = order->add_field();
+            added->set_name("added");
+            added->set_json_name("added");
+            added->set_number(99);
+            added->set_type(google::protobuf::FieldDescriptorProto::TYPE_STRING);
+            added->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+            auto *meta = order->mutable_options()->MutableExtension(
+                confluent::message_meta);
+            meta->clear_rules();
+            auto *rule = meta->add_rules();
+            rule->set_name("added_default");
+            rule->set_expr("this.added == ''");
+        });
+    ASSERT_NE(schema_descriptor, nullptr);
+
+    auto order = protoOrder("ord-1234", 1, {"a"}, "12345");
+    CelValidator validator;
+    auto violations = schemaregistry::serdes::protobuf::utils::validateMessage(
+        validator, order, schema_descriptor, false);
+
+    EXPECT_TRUE(violations.empty()) << violations.size() << " violations";
 }
 
 #endif  // SCHEMAREGISTRY_USE_PROTOBUF

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -732,6 +732,25 @@ std::vector<ValidationRuleError> validateProto(
 
 }  // namespace
 
+TEST(ValidationRuleTest, ProtobufMetaIsReadableFromGeneratedDescriptors) {
+    // Everything the protobuf walker does depends on this, and so does field
+    // encryption, which reads its tags from the same options. If the meta cannot be
+    // read then no rule ever fires and no field is ever encrypted, both silently, so
+    // assert it directly rather than only through a rule's outcome.
+    const auto *desc = test::ValidationOrder::descriptor();
+    auto message_meta = schemaregistry::serdes::protobuf::utils::getMessageMeta(desc);
+    ASSERT_TRUE(message_meta.has_value());
+    ASSERT_EQ(message_meta->rules_size(), 1);
+    EXPECT_EQ(message_meta->rules(0).name(), "quantity_matches_items");
+
+    const auto *field = desc->FindFieldByName("id");
+    ASSERT_NE(field, nullptr);
+    auto field_meta = schemaregistry::serdes::protobuf::utils::getFieldMeta(field);
+    ASSERT_TRUE(field_meta.has_value());
+    ASSERT_EQ(field_meta->rules_size(), 2);
+    EXPECT_EQ(field_meta->rules(0).name(), "id_prefix");
+}
+
 TEST(ValidationRuleTest, ProtobufValidMessageHasNoViolations) {
     EXPECT_TRUE(
         validateProto(protoOrder("ord-1234", 2, {"a", "b"}, "12345")).empty());

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1085,8 +1085,6 @@ TEST(ValidationRuleTest, ProtobufMessageRuleSeesAFieldOnlyTheSchemaDeclares) {
     EXPECT_TRUE(violations.empty()) << violations.size() << " violations";
 }
 
-#endif  // SCHEMAREGISTRY_USE_PROTOBUF
-
 // A field-level rule on a repeated or map field is evaluated once, with the whole
 // collection bound to `this` - matching the JVM client - rather than once per element.
 // A rule about the elements is therefore written as a comprehension over them.
@@ -1227,6 +1225,8 @@ TEST(ValidationRuleTest, ProtobufFieldTransformLeavesMapKeysAlone) {
     // The string fields that are values are still transformed.
     EXPECT_EQ(order->id(), "ord-1234-suffix");
 }
+
+#endif  // SCHEMAREGISTRY_USE_PROTOBUF
 
 #ifdef SCHEMAREGISTRY_USE_JSON
 namespace {

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1401,3 +1401,39 @@ TEST(ValidationRuleTest, JsonFieldTypeIsDerivedFromTheSchema) {
     EXPECT_EQ(typeOf(R"({"type":"unrecognized"})"), FieldType::Null);
 }
 #endif
+
+#ifdef SCHEMAREGISTRY_USE_PROTOBUF
+// cel-cpp is handed the message itself, not a map of its fields, so the engine answers from
+// the descriptor. A well-known type is then the value it wraps rather than a map of seconds
+// and nanos, and these rules have an overload at all.
+TEST(ValidationRuleTest, ProtobufWellKnownTypesBindAsTheValueTheyWrap) {
+    test::ValidationWellKnown obj;
+    obj.mutable_created_at()->set_seconds(1600000000);
+    obj.mutable_name()->set_value("widget");
+    EXPECT_TRUE(validateProto(obj).empty());
+}
+
+TEST(ValidationRuleTest, ProtobufWellKnownTypeRulesStillFire) {
+    // Epoch is not after epoch, and an empty string fails size() > 0.
+    test::ValidationWellKnown obj;
+    obj.mutable_created_at()->set_seconds(0);
+    obj.mutable_name()->set_value("");
+    auto violations = validateProto(obj);
+    EXPECT_NE(findViolation(violations, "created_after_epoch"), nullptr);
+    EXPECT_NE(findViolation(violations, "name_not_empty"), nullptr);
+}
+
+// has() reports protobuf presence: a proto3 scalar left at its default is unset. Built as a
+// map the key was always there, so has() was unconditionally true.
+TEST(ValidationRuleTest, ProtobufHasFollowsProtobufPresence) {
+    test::ValidationPresence unset;
+    auto violations = validateProto(unset);
+    EXPECT_NE(findViolation(violations, "quantity_unset"), nullptr)
+        << "has() reported an unwritten field as set";
+
+    test::ValidationPresence written;
+    written.set_quantity(5);
+    EXPECT_TRUE(validateProto(written).empty())
+        << "has() reported a written field as unset";
+}
+#endif

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1437,3 +1437,82 @@ TEST(ValidationRuleTest, ProtobufHasFollowsProtobufPresence) {
         << "has() reported a written field as unset";
 }
 #endif
+
+#ifdef SCHEMAREGISTRY_USE_JSON
+namespace {
+
+/// A oneOf whose live branch carries a rule, and a sibling reference in that branch
+/// pointing at `pointer`. Matching the branch means compiling it, and a "#/..." reference
+/// resolves against the document root - so the root has to travel with the branch.
+std::string branchSchemaWithRefTo(const std::string &pointer) {
+    return R"schema({
+        "$defs": {"Shared": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "marker": {"type": "string"},
+            "payload": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "other": {"$ref": ")schema" +
+           pointer + R"schema("},
+                            "code": {
+                                "type": "string",
+                                "confluent:rules": [
+                                    {"name": "codeNotEmpty", "expr": "size(this) > 0"}
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    })schema";
+}
+
+std::vector<ValidationRuleError> validateAgainstBranchSchema(
+    const std::string &pointer) {
+    auto client = newMockClient();
+    Schema schema;
+    schema.setSchemaType("JSON");
+    schema.setSchema(std::make_optional(branchSchemaWithRefTo(pointer)));
+    client->registerSchema("test-value", schema, false);
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+    auto ser_config = SerializerConfig::createDefault();
+    ser_config.auto_register_schemas = false;
+    ser_config.use_schema = SchemaSelector::useLatestVersion();
+    ser_config.validation_rules_execution =
+        ValidationRulesExecution::AfterDomainRules;
+    schemaregistry::serdes::json::JsonSerializer ser(
+        client, std::nullopt, rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Json);
+
+    nlohmann::json value = {{"marker", "m"}, {"payload", {{"code", ""}}}};
+    try {
+        ser.serialize(ctx, value);
+        return {};
+    } catch (const ValidationRulesFailedError &e) {
+        return e.getViolations();
+    }
+}
+
+}  // namespace
+
+// A reference into $defs was already reachable, because the definition buckets were copied
+// onto the branch. Kept as the control for the case below.
+TEST(ValidationRuleTest, JsonBranchResolvesRefIntoDefs) {
+    auto violations = validateAgainstBranchSchema("#/$defs/Shared");
+    EXPECT_NE(findViolation(violations, "codeNotEmpty"), nullptr);
+}
+
+// A reference anywhere else in the document used to leave the branch uncompilable, so no
+// branch matched and every rule inside the one the value follows was silently skipped.
+TEST(ValidationRuleTest, JsonBranchResolvesRefOutsideDefs) {
+    auto violations = validateAgainstBranchSchema("#/properties/marker");
+    EXPECT_NE(findViolation(violations, "codeNotEmpty"), nullptr)
+        << "the branch was not matched, so its rules never ran";
+}
+#endif

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -624,6 +624,54 @@ TEST(ValidationRuleTest, JsonFailFastStopsAtFirstViolation) {
     EXPECT_EQ(validateJson(jsonOrder("x", 0, {"a"}, "abc"), true).size(), 1);
 }
 
+// A node carrying both "$ref" and "confluent:rules" declares rules of its own, and the
+// schema it names declares its own: both are charged, at the same location. Resolving the
+// reference before reading the rules dropped the referring node's, silently - the JVM
+// client fires wrapper and target alike, and so do the Go, Python, JS, Rust and .NET
+// clients.
+TEST(ValidationRuleTest, JsonRulesBesideARefAreEvaluatedAsWellAsTheTarget) {
+    const char *schema_str = R"schema({
+        "type": "object",
+        "$defs": {
+            "Inner": {
+                "type": "object",
+                "confluent:rules": [{"name": "target", "expr": "size(this.x) > 0"}],
+                "properties": {"x": {"type": "string"}}
+            }
+        },
+        "properties": {
+            "inner": {
+                "$ref": "#/$defs/Inner",
+                "confluent:rules": [
+                    {"name": "wrapper", "expr": "size(this.x) > 1"}
+                ]
+            }
+        }
+    })schema";
+
+    CelValidator validator;
+    auto validate = [&](const nlohmann::json &value) {
+        return schemaregistry::serdes::json::utils::validateMessage(
+            validator, nlohmann::json::parse(schema_str), value, false);
+    };
+
+    // Satisfies both rules.
+    EXPECT_TRUE(validate(nlohmann::json{{"inner", {{"x", "ab"}}}}).empty());
+
+    // Fails only the rule declared beside the "$ref": the target's rule is happy with one
+    // character, so a violation here can only have come from the referring node.
+    auto wrapper_only = validate(nlohmann::json{{"inner", {{"x", "a"}}}});
+    ASSERT_EQ(wrapper_only.size(), 1u);
+    EXPECT_EQ(wrapper_only[0].rule.name, "wrapper");
+    EXPECT_EQ(wrapper_only[0].field_path, "$.inner");
+
+    // Fails both, so the target is still charged its own.
+    auto both = validate(nlohmann::json{{"inner", {{"x", ""}}}});
+    ASSERT_EQ(both.size(), 2u);
+    EXPECT_NE(findViolation(both, "wrapper"), nullptr);
+    EXPECT_NE(findViolation(both, "target"), nullptr);
+}
+
 TEST(ValidationRuleTest, JsonSkipsAbsentAndNullProperties) {
     nlohmann::json value{{"quantity", 1}, {"items", {"a"}}};
     EXPECT_TRUE(validateJson(value).empty());
@@ -1453,6 +1501,11 @@ TEST(ValidationRuleTest, JsonFieldTypeIsDerivedFromTheSchema) {
     EXPECT_EQ(typeOf(R"({"anyOf":[{"type":"string"},{"type":"integer"}]})"),
               FieldType::Combined);
     EXPECT_EQ(typeOf(R"({"type":"string","enum":["a","b"]})"), FieldType::Enum);
+    // An enumeration is typed by its values and need not declare a type as well, which is
+    // the ordinary way to write one. Read as a typeless node it came out Null - a primitive,
+    // so a field rule ran against it, where the JVM client answers ENUM and skips it.
+    EXPECT_EQ(typeOf(R"({"enum":["a","b"]})"), FieldType::Enum);
+    EXPECT_EQ(typeOf(R"({"const":"a"})"), FieldType::Enum);
     // No type at all: a record if it declares properties, otherwise nothing to act on -
     // and never String, which is what it used to return.
     EXPECT_EQ(typeOf(R"({"properties":{"a":{"type":"string"}}})"), FieldType::Record);

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "schemaregistry/rest/ClientConfiguration.h"
@@ -277,11 +278,13 @@ const char *kAvroSchema = R"schema({
     return datum;
 }
 
-std::vector<ValidationRuleError> validateAvro(const ::avro::GenericDatum &datum,
-                                              bool fail_fast = false) {
+std::vector<ValidationRuleError> validateAvro(
+    const ::avro::GenericDatum &datum, bool fail_fast = false,
+    const std::vector<nlohmann::json> &named_schemas = {}) {
     CelValidator validator;
     return schemaregistry::serdes::avro::utils::validateMessage(
-        validator, nlohmann::json::parse(kAvroSchema), datum, fail_fast);
+        validator, nlohmann::json::parse(kAvroSchema), named_schemas, datum,
+        fail_fast);
 }
 
 }  // namespace
@@ -326,6 +329,59 @@ TEST(ValidationRuleTest, AvroSkipsRulesOnNullFields) {
     ASSERT_EQ(violations.size(), 1);
     EXPECT_EQ(violations[0].rule.name, "note_not_empty");
     EXPECT_EQ(violations[0].field_path, "note");
+}
+
+TEST(ValidationRuleTest, AvroEvaluatesRulesFromReferencedSchemas) {
+    // The datum is built from the resolved schema, but the raw root schema only
+    // names the referenced record, so its rules are reachable only through the
+    // referenced schemas the walk is seeded with.
+    const char *root = R"schema({
+        "type": "record",
+        "name": "Order",
+        "namespace": "test",
+        "fields": [
+            {"name": "address", "type": "test.Address"}
+        ]
+    })schema";
+    const char *referenced = R"schema({
+        "type": "record",
+        "name": "Address",
+        "namespace": "test",
+        "fields": [
+            {"name": "zip", "type": "string",
+             "confluent:rules": [
+                {"name": "zip_digits",
+                 "expr": "this.matches('^[0-9]{5}$') ? '' : 'zip must be 5 digits'"}
+             ]}
+        ]
+    })schema";
+    const char *resolved = R"schema({
+        "type": "record",
+        "name": "Order",
+        "namespace": "test",
+        "fields": [
+            {"name": "address", "type": {
+                "type": "record",
+                "name": "Address",
+                "fields": [{"name": "zip", "type": "string"}]
+            }}
+        ]
+    })schema";
+
+    auto schema = ::avro::compileJsonSchemaFromString(resolved);
+    ::avro::GenericDatum datum(schema);
+    auto &record = datum.value<::avro::GenericRecord>();
+    record.fieldAt(0).value<::avro::GenericRecord>().setFieldAt(
+        0, ::avro::GenericDatum(std::string("abc")));
+
+    CelValidator validator;
+    std::vector<nlohmann::json> named_schemas{
+        nlohmann::json::parse(referenced)};
+    auto violations = schemaregistry::serdes::avro::utils::validateMessage(
+        validator, nlohmann::json::parse(root), named_schemas, datum, false);
+    ASSERT_EQ(violations.size(), 1);
+    EXPECT_EQ(violations[0].rule.name, "zip_digits");
+    EXPECT_EQ(violations[0].field_path, "address.zip");
 }
 
 TEST(ValidationRuleTest, AvroSerializerRejectsInvalidMessage) {
@@ -596,6 +652,53 @@ TEST(ValidationRuleTest, JsonSerializerRejectsInvalidMessage) {
         ValidationRulesFailedError);
 }
 
+TEST(ValidationRuleTest, JsonOneOfPicksTheBranchTheValueSatisfies) {
+    // Both branches are objects, so they cannot be told apart by JSON type:
+    // they differ by the "kind" const. Evaluating both branches' rules would
+    // reject a valid message.
+    const char *schema = R"schema({
+        "type": "object",
+        "properties": {
+            "payload": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "kind": {"const": "a"},
+                            "v": {"type": "integer",
+                                  "confluent:rules": [{"name": "ruleA", "expr": "false"}]}
+                        },
+                        "required": ["kind"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "kind": {"const": "b"},
+                            "v": {"type": "integer",
+                                  "confluent:rules": [{"name": "ruleB", "expr": "false"}]}
+                        },
+                        "required": ["kind"]
+                    }
+                ]
+            }
+        }
+    })schema";
+
+    CelValidator validator;
+    auto parsed = nlohmann::json::parse(schema);
+    for (const auto &[kind, expected] :
+         std::vector<std::pair<std::string, std::string>>{{"a", "ruleA"},
+                                                          {"b", "ruleB"}}) {
+        nlohmann::json value = {{"payload", {{"kind", kind}, {"v", 1}}}};
+        auto violations = schemaregistry::serdes::json::utils::validateMessage(
+            validator, parsed, value, false);
+        ASSERT_EQ(violations.size(), 1u)
+            << "kind " << kind << ": " << violations.size();
+        EXPECT_EQ(violations[0].rule.name, expected);
+        EXPECT_EQ(violations[0].field_path, "$.payload.v");
+    }
+}
+
 #endif  // SCHEMAREGISTRY_USE_JSON
 
 // --- Protobuf -------------------------------------------------------------
@@ -766,6 +869,26 @@ TEST(ValidationRuleTest, ProtobufPreservesUnsignedValues) {
     auto violations = validateProto(order);
     ASSERT_EQ(violations.size(), 1u);
     EXPECT_EQ(violations[0].rule.name, "serial_positive");
+}
+
+TEST(ValidationRuleTest, MessageLevelRulesSeeUnsignedFieldsAndMaps) {
+    test::ValidationMessageLevel message;
+    message.set_serial(std::numeric_limits<uint64_t>::max());
+    (*message.mutable_scores())["ok"] = 0;
+
+    auto violations = validateProto(message);
+    for (const auto &violation : violations) {
+        EXPECT_TRUE(violation.cause.empty())
+            << "message-level rule failed to evaluate: "
+            << violation.toString();
+    }
+    EXPECT_EQ(violations.size(), 0u);
+
+    // and the rule really does run: a zero serial fails it
+    message.set_serial(0);
+    auto failures = validateProto(message);
+    ASSERT_EQ(failures.size(), 1u);
+    EXPECT_EQ(failures[0].rule.name, "sees_serial_and_scores");
 }
 
 #endif  // SCHEMAREGISTRY_USE_PROTOBUF

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -37,6 +37,7 @@
 
 #ifdef SCHEMAREGISTRY_USE_JSON
 #include "schemaregistry/serdes/json/JsonSerializer.h"
+#include "schemaregistry/serdes/json/JsonTypes.h"
 #include "schemaregistry/serdes/json/JsonUtils.h"
 #endif
 
@@ -1226,3 +1227,75 @@ TEST(ValidationRuleTest, ProtobufFieldTransformLeavesMapKeysAlone) {
     // The string fields that are values are still transformed.
     EXPECT_EQ(order->id(), "ord-1234-suffix");
 }
+
+#ifdef SCHEMAREGISTRY_USE_JSON
+namespace {
+
+// A root whose text is the same whichever schema it references. What its "$ref"
+// resolves to is decided entirely by the reference list on the Schema.
+constexpr const char *kSharedRoot = R"schema({
+    "type": "object",
+    "properties": {"payload": {"$ref": "ref"}}
+})schema";
+
+// Two referenced schemas that differ only in the rule they declare.
+std::string refSchemaRequiring(const std::string &prefix,
+                               const std::string &rule_name) {
+    return R"schema({
+        "type": "object",
+        "properties": {"code": {"type": "string",
+            "confluent:rules": [{"name": ")schema" +
+           rule_name + R"schema(",
+             "expr": "this.startsWith(')schema" +
+           prefix + R"schema(') ? '' : 'wrong prefix'"}]}}
+    })schema";
+}
+
+Schema rootReferencing(const std::string &subject) {
+    SchemaReference ref;
+    ref.setName(std::make_optional<std::string>("ref"));
+    ref.setSubject(std::make_optional<std::string>(subject));
+    ref.setVersion(std::make_optional<int32_t>(1));
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("JSON"));
+    schema.setSchema(std::make_optional<std::string>(kSharedRoot));
+    schema.setReferences(
+        std::make_optional<std::vector<SchemaReference>>({ref}));
+    return schema;
+}
+
+}  // namespace
+
+TEST(ValidationRuleTest, JsonSchemaCacheSeparatesSchemasByTheirReferences) {
+    auto client = newMockClient();
+    for (const auto &subject : {std::string("ref-a"), std::string("ref-b")}) {
+        Schema ref_schema;
+        ref_schema.setSchemaType(std::make_optional<std::string>("JSON"));
+        ref_schema.setSchema(std::make_optional<std::string>(
+            refSchemaRequiring(subject == "ref-a" ? "A" : "B",
+                               subject == "ref-a" ? "code_a" : "code_b")));
+        client->registerSchema(subject, ref_schema, false);
+    }
+
+    // One serde, so both lookups go through the same cache. The two schemas
+    // agree on every byte of their text and differ only in what they reference,
+    // which is exactly the pair a text-keyed cache would conflate.
+    schemaregistry::serdes::json::JsonSerde serde;
+    auto flattened_a = serde.getSchemaJson(rootReferencing("ref-a"), client);
+    auto flattened_b = serde.getSchemaJson(rootReferencing("ref-b"), client);
+
+    ASSERT_NE(flattened_a, nullptr);
+    ASSERT_NE(flattened_b, nullptr);
+    EXPECT_NE(flattened_a, flattened_b)
+        << "the second schema was served the first one's flattened document";
+    EXPECT_NE(flattened_a->dump().find("code_a"), std::string::npos);
+    EXPECT_NE(flattened_b->dump().find("code_b"), std::string::npos);
+    EXPECT_EQ(flattened_b->dump().find("code_a"), std::string::npos)
+        << "rules from the other schema's reference leaked in";
+
+    // The same schema still hits the cache rather than re-resolving.
+    EXPECT_EQ(serde.getSchemaJson(rootReferencing("ref-a"), client),
+              flattened_a);
+}
+#endif

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -113,6 +113,39 @@ TEST(ValidationRuleTest, CelValidatorReturnsMessage) {
     EXPECT_EQ(std::get<std::string>(result), "must be an adult");
 }
 
+// The JVM client registers both CEL extensions - strings and math - so a rule written
+// against either resolves there. The string extension was already registered here; the math
+// one supplies math.greatest/least, the rounding and sign functions, and the bit operations.
+TEST(ValidationRuleTest, CelResolvesBothExtensions) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"name", "alice"}});
+
+    for (const char *expr : {
+             // math
+             "math.greatest(1, 5, 3) == 5",
+             "math.least(1, 5, 3) == 1",
+             "math.abs(-4) == 4",
+             "math.ceil(1.2) == 2.0",
+             "math.floor(1.8) == 1.0",
+             "math.round(1.5) == 2.0",
+             "math.trunc(1.9) == 1.0",
+             "math.sign(-3) == -1",
+             "math.isNaN(0.0/0.0)",
+             "math.bitAnd(12, 10) == 8",
+             "math.bitOr(12, 10) == 14",
+             "math.bitXor(12, 10) == 6",
+             "math.bitShiftLeft(1, 3) == 8",
+             "math.bitShiftRight(8, 3) == 1",
+             // strings, unchanged
+             "'AbC'.lowerAscii() == 'abc'",
+             "'a-b'.split('-') == ['a', 'b']",
+         }) {
+        auto result = validator.execute(rule("n", expr), *value);
+        ASSERT_TRUE(std::holds_alternative<bool>(result)) << expr;
+        EXPECT_TRUE(std::get<bool>(result)) << expr;
+    }
+}
+
 TEST(ValidationRuleTest, CelValidatorRejectsNonBooleanResult) {
     CelValidator validator;
     auto value = json::makeJsonValue(nlohmann::json{{"age", 3}});

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "schemaregistry/rest/ClientConfiguration.h"
+#include "schemaregistry/rest/MockSchemaRegistryClient.h"
 #include "schemaregistry/rest/SchemaRegistryClient.h"
 #include "schemaregistry/rest/model/Rule.h"
 #include "schemaregistry/rest/model/RuleSet.h"
@@ -671,6 +672,57 @@ TEST(ValidationRuleTest, ProtobufSerializerRejectsInvalidMessage) {
     EXPECT_THROW(
         serializer.serialize(ctx, protoOrder("bad", 2, {"a", "b"}, "12345")),
         ValidationRulesFailedError);
+}
+
+TEST(ValidationRuleTest, ProtobufAllowsDefaultedProto3Scalars) {
+    // quantity and items are both at their proto3 defaults, so
+    // "this.quantity == size(this.items)" holds; the message-level rule must be
+    // able to see them rather than failing with "no such key".
+    test::ValidationOrder order;
+    order.set_id("ord-1234");
+    auto violations = validateProto(order);
+
+    for (const auto &violation : violations) {
+        EXPECT_TRUE(violation.cause.empty())
+            << "no rule should fail to evaluate: " << violation.toString();
+    }
+    EXPECT_EQ(findViolation(violations, "quantity_matches_items"), nullptr);
+    // quantity = 0 still legitimately fails "this > 0".
+    ASSERT_EQ(violations.size(), 1);
+    EXPECT_EQ(violations[0].rule.name, "positive_quantity");
+}
+
+TEST(ValidationRuleTest, ProtobufUsesTheSelectedSchemasDescriptor) {
+    auto client = std::make_shared<MockSchemaRegistryClient>(
+        std::make_shared<const ClientConfiguration>(
+            std::vector<std::string>{"mock://"}));
+
+    test::ValidationOrder invalid = protoOrder("bad", 2, {"a", "b"}, "12345");
+    Schema schema;
+    schema.setSchemaType("PROTOBUF");
+    schema.setSchema(
+        protobuf::utils::schemaToString(invalid.GetDescriptor()->file()));
+    client->registerSchema("test-value", schema, false);
+
+    auto ser_config = SerializerConfig(
+        false, std::make_optional(SchemaSelector::useLatestVersion()), false,
+        false, std::unordered_map<std::string, std::string>{});
+    ser_config.validation_rules_execution =
+        ValidationRulesExecution::AfterDomainRules;
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+
+    schemaregistry::serdes::protobuf::ProtobufSerializer<test::ValidationOrder>
+        serializer(client, std::nullopt, rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Protobuf);
+
+    // Rules are read from the descriptor parsed out of the selected registry
+    // schema, not from the caller's compiled-in one.
+    EXPECT_THROW(serializer.serialize(ctx, invalid),
+                 ValidationRulesFailedError);
+    EXPECT_NO_THROW(serializer.serialize(
+        ctx, protoOrder("ord-1234", 2, {"a", "b"}, "12345")));
 }
 
 #endif  // SCHEMAREGISTRY_USE_PROTOBUF

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -446,6 +447,30 @@ TEST(ValidationRuleTest, AvroSerializerRunsValidationAfterDomainRules) {
     }
 }
 
+TEST(ValidationRuleTest, AvroInlineTagsQualifyRecordNames) {
+    // The fullname of "foobar" in namespace "foo" is "foo.foobar". Treating the
+    // namespace as an already-present prefix keys the tags under "foobar",
+    // which never matches, and the tags - which drive field encryption - are
+    // silently dropped.
+    auto tags = schemaregistry::serdes::avro::utils::getInlineTags(
+        nlohmann::json::parse(R"schema({
+            "type": "record", "namespace": "foo", "name": "foobar",
+            "fields": [{"name": "x", "type": "string", "confluent:tags": ["PII"]}]
+        })schema"));
+    ASSERT_EQ(tags.count("foo.foobar.x"), 1u)
+        << "tags keyed under the wrong name";
+    EXPECT_EQ(tags.at("foo.foobar.x").count("PII"), 1u);
+
+    // A dotted name is already a fullname, so the namespace attribute is
+    // ignored.
+    auto dotted = schemaregistry::serdes::avro::utils::getInlineTags(
+        nlohmann::json::parse(R"schema({
+            "type": "record", "namespace": "x", "name": "a.B",
+            "fields": [{"name": "y", "type": "string", "confluent:tags": ["PII"]}]
+        })schema"));
+    ASSERT_EQ(dotted.count("a.B.y"), 1u) << "namespace prepended to a fullname";
+}
+
 #endif  // SCHEMAREGISTRY_USE_AVRO
 
 // --- JSON Schema ----------------------------------------------------------
@@ -589,6 +614,9 @@ test::ValidationOrder protoOrder(const std::string &id, int32_t quantity,
         order.add_items(item);
     }
     order.mutable_address()->set_zip(zip);
+    // serial has a positive rule; keep it valid so tests assert only what they
+    // target.
+    order.set_serial(1);
     return order;
 }
 
@@ -651,6 +679,7 @@ TEST(ValidationRuleTest, ProtobufSkipsRulesOnUnsetMessageFields) {
     order.set_id("ord-1234");
     order.set_quantity(1);
     order.add_items("a");
+    order.set_serial(1);
     EXPECT_TRUE(validateProto(order).empty());
 }
 
@@ -680,6 +709,7 @@ TEST(ValidationRuleTest, ProtobufAllowsDefaultedProto3Scalars) {
     // able to see them rather than failing with "no such key".
     test::ValidationOrder order;
     order.set_id("ord-1234");
+    order.set_serial(1);
     auto violations = validateProto(order);
 
     for (const auto &violation : violations) {
@@ -723,6 +753,19 @@ TEST(ValidationRuleTest, ProtobufUsesTheSelectedSchemasDescriptor) {
                  ValidationRulesFailedError);
     EXPECT_NO_THROW(serializer.serialize(
         ctx, protoOrder("ord-1234", 2, {"a", "b"}, "12345")));
+}
+
+TEST(ValidationRuleTest, ProtobufPreservesUnsignedValues) {
+    // A uint64 above int64 max narrowed to a signed value reads as negative, so
+    // a "this > 0" rule would reject a perfectly valid serial number.
+    test::ValidationOrder order = protoOrder("ord-1234", 1, {"a"}, "12345");
+    order.set_serial(std::numeric_limits<uint64_t>::max());
+    EXPECT_EQ(validateProto(order).size(), 0u);
+
+    order.set_serial(0);
+    auto violations = validateProto(order);
+    ASSERT_EQ(violations.size(), 1u);
+    EXPECT_EQ(violations[0].rule.name, "serial_positive");
 }
 
 #endif  // SCHEMAREGISTRY_USE_PROTOBUF

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1,0 +1,676 @@
+/**
+ * ValidationRuleTest
+ * Tests for inline validation rules ("confluent:rules" / confluent.Meta rules)
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "schemaregistry/rest/ClientConfiguration.h"
+#include "schemaregistry/rest/SchemaRegistryClient.h"
+#include "schemaregistry/rest/model/Rule.h"
+#include "schemaregistry/rest/model/RuleSet.h"
+#include "schemaregistry/rest/model/Schema.h"
+#include "schemaregistry/rules/cel/CelExecutor.h"
+#include "schemaregistry/rules/cel/CelValidator.h"
+#include "schemaregistry/serdes/RuleRegistry.h"
+#include "schemaregistry/serdes/SerdeConfig.h"
+#include "schemaregistry/serdes/ValidationRule.h"
+#include "schemaregistry/serdes/json/JsonValue.h"
+
+#ifdef SCHEMAREGISTRY_USE_AVRO
+#include <avro/Generic.hh>
+#include <avro/ValidSchema.hh>
+
+#include "schemaregistry/serdes/avro/AvroSerializer.h"
+#include "schemaregistry/serdes/avro/AvroUtils.h"
+#endif
+
+#ifdef SCHEMAREGISTRY_USE_JSON
+#include "schemaregistry/serdes/json/JsonSerializer.h"
+#include "schemaregistry/serdes/json/JsonUtils.h"
+#endif
+
+#ifdef SCHEMAREGISTRY_USE_PROTOBUF
+#include "schemaregistry/serdes/protobuf/ProtobufSerializer.h"
+#include "schemaregistry/serdes/protobuf/ProtobufUtils.h"
+#include "test/validation.pb.h"
+#endif
+
+using namespace schemaregistry::serdes;
+using namespace schemaregistry::rest;
+using namespace schemaregistry::rest::model;
+using schemaregistry::rules::cel::CelValidator;
+
+namespace {
+
+ValidationRule rule(const std::string &name, const std::string &expr,
+                    const std::string &doc = "") {
+    return ValidationRule{name, doc, expr, ""};
+}
+
+std::shared_ptr<ISchemaRegistryClient> newMockClient() {
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    return SchemaRegistryClient::newClient(client_config);
+}
+
+// Locates a violation by rule name; returns nullptr when there is none.
+const ValidationRuleError *findViolation(
+    const std::vector<ValidationRuleError> &violations,
+    const std::string &name) {
+    for (const auto &violation : violations) {
+        if (violation.rule.name == name) {
+            return &violation;
+        }
+    }
+    return nullptr;
+}
+
+SerializationContext valueContext(SerdeFormat format) {
+    SerializationContext ctx;
+    ctx.topic = "test";
+    ctx.serde_type = SerdeType::Value;
+    ctx.serde_format = format;
+    return ctx;
+}
+
+}  // namespace
+
+// --- CelValidator ---------------------------------------------------------
+
+TEST(ValidationRuleTest, CelValidatorReturnsBool) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"name", "alice"}});
+
+    auto passing = validator.execute(rule("n", "this.name == 'alice'"), *value);
+    ASSERT_TRUE(std::holds_alternative<bool>(passing));
+    EXPECT_TRUE(std::get<bool>(passing));
+
+    auto failing = validator.execute(rule("n", "this.name == 'bob'"), *value);
+    ASSERT_TRUE(std::holds_alternative<bool>(failing));
+    EXPECT_FALSE(std::get<bool>(failing));
+}
+
+TEST(ValidationRuleTest, CelValidatorReturnsMessage) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"age", 3}});
+
+    auto result = validator.execute(
+        rule("n", "this.age >= 18 ? '' : 'must be an adult'"), *value);
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), "must be an adult");
+}
+
+TEST(ValidationRuleTest, CelValidatorRejectsNonBooleanResult) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"age", 3}});
+
+    EXPECT_THROW(validator.execute(rule("n", "this.age"), *value), SerdeError);
+}
+
+TEST(ValidationRuleTest, CelValidatorRejectsEmptyExpression) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"age", 3}});
+
+    EXPECT_THROW(validator.execute(rule("n", ""), *value), SerdeError);
+}
+
+TEST(ValidationRuleTest, FailedRuleBecomesAViolationWithItsCause) {
+    CelValidator validator;
+    auto value = json::makeJsonValue(nlohmann::json{{"age", 3}});
+    std::vector<ValidationRuleError> violations;
+
+    // A rule that cannot be evaluated is recorded as a violation rather than
+    // aborting the walk.
+    EXPECT_TRUE(evaluateValidationRule(validator, rule("bad", "this.missing"),
+                                       *value, "$", violations));
+    ASSERT_EQ(violations.size(), 1);
+    EXPECT_EQ(violations[0].field_path, "$");
+    EXPECT_FALSE(violations[0].cause.empty());
+}
+
+TEST(ValidationRuleTest, ViolationMessagePrefersDynamicThenDocThenExpr) {
+    ValidationRuleError with_message{rule("r", "expr", "doc"), "a.b", "dynamic",
+                                     ""};
+    EXPECT_EQ(with_message.toString(), "a.b: r: dynamic");
+
+    ValidationRuleError with_doc{rule("r", "expr", "doc"), "a.b", "", ""};
+    EXPECT_EQ(with_doc.toString(), "a.b: r: doc");
+
+    ValidationRuleError with_expr{rule("r", "expr"), "", "", ""};
+    EXPECT_EQ(with_expr.toString(), "<root>: r: expr");
+
+    ValidationRuleError unnamed{rule("", "expr"), "", "", "boom"};
+    EXPECT_EQ(unnamed.toString(), "<root>: unnamed: expr (caused by: boom)");
+}
+
+TEST(ValidationRuleTest, AggregatedErrorListsEveryViolation) {
+    std::vector<ValidationRuleError> violations = {
+        {rule("a", "e1"), "x", "", ""}, {rule("b", "e2"), "y", "", ""}};
+    try {
+        raiseValidationViolations(violations);
+        FAIL() << "expected ValidationRulesFailedError";
+    } catch (const ValidationRulesFailedError &e) {
+        EXPECT_EQ(e.getViolations().size(), 2);
+        std::string message = e.what();
+        EXPECT_NE(message.find("2 violations"), std::string::npos);
+        EXPECT_NE(message.find("x: a: e1"), std::string::npos);
+        EXPECT_NE(message.find("y: b: e2"), std::string::npos);
+    }
+}
+
+TEST(ValidationRuleTest, NoViolationsRaisesNothing) {
+    EXPECT_NO_THROW(raiseValidationViolations({}));
+}
+
+TEST(ValidationRuleTest, ParsesRulesFromSchemaProperty) {
+    auto rules = parseValidationRules(nlohmann::json::parse(R"([
+        {"name": "a", "doc": "d", "expr": "e", "sql": "s"},
+        {"name": "b"},
+        "not an object"
+    ])"));
+    ASSERT_EQ(rules.size(), 2);
+    EXPECT_EQ(rules[0].name, "a");
+    EXPECT_EQ(rules[0].doc, "d");
+    EXPECT_EQ(rules[0].expr, "e");
+    EXPECT_EQ(rules[0].sql, "s");
+    EXPECT_EQ(rules[1].name, "b");
+    EXPECT_TRUE(rules[1].expr.empty());
+
+    EXPECT_TRUE(parseValidationRules(nlohmann::json::object()).empty());
+}
+
+TEST(ValidationRuleTest, ParsesExecutionMode) {
+    EXPECT_EQ(parseValidationRulesExecution("DISABLED"),
+              ValidationRulesExecution::Disabled);
+    EXPECT_EQ(parseValidationRulesExecution("BEFORE_DOMAIN_RULES"),
+              ValidationRulesExecution::BeforeDomainRules);
+    EXPECT_EQ(parseValidationRulesExecution("AFTER_DOMAIN_RULES"),
+              ValidationRulesExecution::AfterDomainRules);
+    EXPECT_FALSE(parseValidationRulesExecution("nonsense").has_value());
+}
+
+TEST(ValidationRuleTest, ValidationIsDisabledByDefault) {
+    EXPECT_EQ(SerializerConfig::createDefault().validation_rules_execution,
+              ValidationRulesExecution::Disabled);
+    EXPECT_FALSE(SerializerConfig::createDefault().validation_rules_fail_fast);
+}
+
+// --- Avro -----------------------------------------------------------------
+
+#ifdef SCHEMAREGISTRY_USE_AVRO
+
+namespace {
+
+const char *kAvroSchema = R"schema({
+    "type": "record",
+    "name": "Order",
+    "namespace": "test",
+    "confluent:rules": [
+        {"name": "quantity_matches_items",
+         "expr": "this.quantity == size(this.items)"}
+    ],
+    "fields": [
+        {"name": "id", "type": "string",
+         "confluent:rules": [
+            {"name": "id_prefix", "expr": "this.startsWith('ord-')"},
+            {"name": "id_length", "expr": "size(this) > 4 ? '' : 'id is too short'"}
+         ]},
+        {"name": "quantity", "type": "int",
+         "confluent:rules": [
+            {"name": "positive_quantity", "doc": "quantity must be positive",
+             "expr": "this > 0"}
+         ]},
+        {"name": "items", "type": {"type": "array", "items": "string"}},
+        {"name": "note", "type": ["null", "string"],
+         "confluent:rules": [
+            {"name": "note_not_empty", "expr": "size(this) > 0"}
+         ]},
+        {"name": "address", "type": {
+            "type": "record",
+            "name": "Address",
+            "fields": [
+                {"name": "zip", "type": "string",
+                 "confluent:rules": [
+                    {"name": "zip_digits",
+                     "expr": "this.matches('^[0-9]{5}$') ? '' : 'zip must be 5 digits'"}
+                 ]}
+            ]
+        }}
+    ]
+})schema";
+
+::avro::GenericDatum makeAvroOrder(const std::string &id, int32_t quantity,
+                                   const std::vector<std::string> &items,
+                                   const std::string &zip,
+                                   bool with_note = false,
+                                   const std::string &note = "") {
+    auto schema =
+        schemaregistry::serdes::avro::AvroSerializer::compileJsonSchema(
+            kAvroSchema);
+    ::avro::GenericDatum datum(schema);
+    auto &record = datum.value<::avro::GenericRecord>();
+    record.setFieldAt(0, ::avro::GenericDatum(id));
+    record.setFieldAt(1, ::avro::GenericDatum(quantity));
+
+    auto &items_datum = record.fieldAt(2);
+    auto &array = items_datum.value<::avro::GenericArray>();
+    for (const auto &item : items) {
+        array.value().push_back(::avro::GenericDatum(item));
+    }
+
+    if (with_note) {
+        auto &note_datum = record.fieldAt(3);
+        note_datum.selectBranch(1);
+        note_datum.value<std::string>() = note;
+    }
+
+    auto &address = record.fieldAt(4).value<::avro::GenericRecord>();
+    address.setFieldAt(0, ::avro::GenericDatum(zip));
+    return datum;
+}
+
+std::vector<ValidationRuleError> validateAvro(const ::avro::GenericDatum &datum,
+                                              bool fail_fast = false) {
+    CelValidator validator;
+    return schemaregistry::serdes::avro::utils::validateMessage(
+        validator, nlohmann::json::parse(kAvroSchema), datum, fail_fast);
+}
+
+}  // namespace
+
+TEST(ValidationRuleTest, AvroValidRecordHasNoViolations) {
+    auto datum = makeAvroOrder("ord-1234", 2, {"a", "b"}, "12345");
+    EXPECT_TRUE(validateAvro(datum).empty());
+}
+
+TEST(ValidationRuleTest, AvroCollectsEveryViolation) {
+    // Fails: id prefix, id length, quantity, record-level count, nested zip.
+    auto datum = makeAvroOrder("x", 0, {"a"}, "abc");
+    auto violations = validateAvro(datum);
+
+    ASSERT_EQ(violations.size(), 5);
+    EXPECT_EQ(violations[0].rule.name, "quantity_matches_items");
+    EXPECT_EQ(violations[0].field_path, "");
+    EXPECT_EQ(violations[1].rule.name, "id_prefix");
+    EXPECT_EQ(violations[1].field_path, "id");
+    EXPECT_EQ(violations[2].rule.name, "id_length");
+    EXPECT_EQ(violations[2].message, "id is too short");
+    EXPECT_EQ(violations[3].rule.name, "positive_quantity");
+    EXPECT_EQ(violations[3].field_path, "quantity");
+    EXPECT_EQ(violations[4].rule.name, "zip_digits");
+    EXPECT_EQ(violations[4].field_path, "address.zip");
+    EXPECT_EQ(violations[4].message, "zip must be 5 digits");
+}
+
+TEST(ValidationRuleTest, AvroFailFastStopsAtFirstViolation) {
+    auto datum = makeAvroOrder("x", 0, {"a"}, "abc");
+    EXPECT_EQ(validateAvro(datum, true).size(), 1);
+}
+
+TEST(ValidationRuleTest, AvroSkipsRulesOnNullFields) {
+    // note is null, so note_not_empty must not be invoked.
+    auto datum = makeAvroOrder("ord-1234", 2, {"a", "b"}, "12345");
+    EXPECT_TRUE(validateAvro(datum).empty());
+
+    auto with_note =
+        makeAvroOrder("ord-1234", 2, {"a", "b"}, "12345", true, "");
+    auto violations = validateAvro(with_note);
+    ASSERT_EQ(violations.size(), 1);
+    EXPECT_EQ(violations[0].rule.name, "note_not_empty");
+    EXPECT_EQ(violations[0].field_path, "note");
+}
+
+TEST(ValidationRuleTest, AvroSerializerRejectsInvalidMessage) {
+    auto client = newMockClient();
+    auto ser_config = SerializerConfig::createDefault();
+    ser_config.validation_rules_execution =
+        ValidationRulesExecution::AfterDomainRules;
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("AVRO"));
+    schema.setSchema(std::make_optional<std::string>(kAvroSchema));
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+
+    schemaregistry::serdes::avro::AvroSerializer serializer(
+        client, std::make_optional(schema), rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Avro);
+
+    EXPECT_NO_THROW(serializer.serialize(
+        ctx, makeAvroOrder("ord-1234", 2, {"a", "b"}, "12345")));
+    EXPECT_THROW(
+        serializer.serialize(ctx, makeAvroOrder("bad", 2, {"a", "b"}, "12345")),
+        ValidationRulesFailedError);
+}
+
+TEST(ValidationRuleTest, AvroSerializerSkipsValidationWhenDisabled) {
+    auto client = newMockClient();
+    auto ser_config = SerializerConfig::createDefault();
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("AVRO"));
+    schema.setSchema(std::make_optional<std::string>(kAvroSchema));
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+
+    schemaregistry::serdes::avro::AvroSerializer serializer(
+        client, std::make_optional(schema), rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Avro);
+
+    EXPECT_NO_THROW(serializer.serialize(
+        ctx, makeAvroOrder("bad", 2, {"a", "b"}, "12345")));
+}
+
+namespace {
+
+// Registers a schema whose domain rule always fails, so that the order of the
+// two failures tells us which phase ran first.
+void registerSchemaWithFailingDomainRule(
+    const std::shared_ptr<ISchemaRegistryClient> &client) {
+    Rule cel_rule;
+    cel_rule.setName(std::make_optional<std::string>("always-fails"));
+    cel_rule.setKind(std::make_optional<Kind>(Kind::Condition));
+    cel_rule.setMode(std::make_optional<Mode>(Mode::Write));
+    cel_rule.setType(std::make_optional<std::string>("CEL"));
+    cel_rule.setExpr(std::make_optional<std::string>("message.quantity > 100"));
+    RuleSet rule_set;
+    rule_set.setDomainRules(std::make_optional<std::vector<Rule>>({cel_rule}));
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("AVRO"));
+    schema.setSchema(std::make_optional<std::string>(kAvroSchema));
+    schema.setRuleSet(std::make_optional<RuleSet>(rule_set));
+    client->registerSchema("test-value", schema, false);
+}
+
+std::shared_ptr<RuleRegistry> newValidatingRegistry() {
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(
+        std::make_shared<schemaregistry::rules::cel::CelExecutor>());
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+    return rule_registry;
+}
+
+SerializerConfig latestVersionConfig(ValidationRulesExecution execution) {
+    auto config = SerializerConfig(
+        false, std::make_optional(SchemaSelector::useLatestVersion()), true,
+        false, std::unordered_map<std::string, std::string>{});
+    config.validation_rules_execution = execution;
+    return config;
+}
+
+}  // namespace
+
+TEST(ValidationRuleTest, AvroSerializerRunsValidationBeforeDomainRules) {
+    auto client = newMockClient();
+    registerSchemaWithFailingDomainRule(client);
+
+    schemaregistry::serdes::avro::AvroSerializer serializer(
+        client, std::nullopt, newValidatingRegistry(),
+        latestVersionConfig(ValidationRulesExecution::BeforeDomainRules));
+    auto ctx = valueContext(SerdeFormat::Avro);
+
+    // Both the inline rules and the domain rule fail; validation first means
+    // the validation failure is what surfaces.
+    EXPECT_THROW(
+        serializer.serialize(ctx, makeAvroOrder("bad", 2, {"a", "b"}, "12345")),
+        ValidationRulesFailedError);
+}
+
+TEST(ValidationRuleTest, AvroSerializerRunsValidationAfterDomainRules) {
+    auto client = newMockClient();
+    registerSchemaWithFailingDomainRule(client);
+
+    schemaregistry::serdes::avro::AvroSerializer serializer(
+        client, std::nullopt, newValidatingRegistry(),
+        latestVersionConfig(ValidationRulesExecution::AfterDomainRules));
+    auto ctx = valueContext(SerdeFormat::Avro);
+
+    // Same message, but the domain rule now runs first, so its failure is what
+    // surfaces instead of the validation failure.
+    try {
+        serializer.serialize(ctx, makeAvroOrder("bad", 2, {"a", "b"}, "12345"));
+        FAIL() << "expected the domain rule to fail";
+    } catch (const SerdeError &e) {
+        EXPECT_EQ(dynamic_cast<const ValidationRulesFailedError *>(&e),
+                  nullptr);
+    }
+}
+
+#endif  // SCHEMAREGISTRY_USE_AVRO
+
+// --- JSON Schema ----------------------------------------------------------
+
+#ifdef SCHEMAREGISTRY_USE_JSON
+
+namespace {
+
+const char *kJsonSchema = R"schema({
+    "type": "object",
+    "confluent:rules": [
+        {"name": "quantity_matches_items",
+         "expr": "this.quantity == size(this.items)"}
+    ],
+    "properties": {
+        "id": {
+            "type": "string",
+            "confluent:rules": [
+                {"name": "id_prefix", "expr": "this.startsWith('ord-')"}
+            ]
+        },
+        "quantity": {
+            "type": "integer",
+            "confluent:rules": [
+                {"name": "positive_quantity", "expr": "this > 0"}
+            ]
+        },
+        "items": {"type": "array", "items": {"type": "string"}},
+        "address": {"$ref": "#/definitions/Address"}
+    },
+    "definitions": {
+        "Address": {
+            "type": "object",
+            "properties": {
+                "zip": {
+                    "type": "string",
+                    "confluent:rules": [
+                        {"name": "zip_digits",
+                         "expr": "this.matches('^[0-9]{5}$') ? '' : 'zip must be 5 digits'"}
+                    ]
+                }
+            }
+        }
+    }
+})schema";
+
+std::vector<ValidationRuleError> validateJson(const nlohmann::json &value,
+                                              bool fail_fast = false) {
+    CelValidator validator;
+    return schemaregistry::serdes::json::utils::validateMessage(
+        validator, nlohmann::json::parse(kJsonSchema), value, fail_fast);
+}
+
+nlohmann::json jsonOrder(const std::string &id, int quantity,
+                         const std::vector<std::string> &items,
+                         const std::string &zip) {
+    return nlohmann::json{{"id", id},
+                          {"quantity", quantity},
+                          {"items", items},
+                          {"address", {{"zip", zip}}}};
+}
+
+}  // namespace
+
+TEST(ValidationRuleTest, JsonValidObjectHasNoViolations) {
+    EXPECT_TRUE(
+        validateJson(jsonOrder("ord-1", 2, {"a", "b"}, "12345")).empty());
+}
+
+TEST(ValidationRuleTest, JsonCollectsEveryViolationWithDollarRootedPaths) {
+    auto violations = validateJson(jsonOrder("x", 0, {"a"}, "abc"));
+
+    // Properties are walked in the instance's key order, so assert on the set
+    // of violations rather than their sequence.
+    ASSERT_EQ(violations.size(), 4);
+    ASSERT_NE(findViolation(violations, "quantity_matches_items"), nullptr);
+    EXPECT_EQ(findViolation(violations, "quantity_matches_items")->field_path,
+              "$");
+    ASSERT_NE(findViolation(violations, "id_prefix"), nullptr);
+    EXPECT_EQ(findViolation(violations, "id_prefix")->field_path, "$.id");
+    ASSERT_NE(findViolation(violations, "positive_quantity"), nullptr);
+    EXPECT_EQ(findViolation(violations, "positive_quantity")->field_path,
+              "$.quantity");
+    // Resolved through "$ref".
+    ASSERT_NE(findViolation(violations, "zip_digits"), nullptr);
+    EXPECT_EQ(findViolation(violations, "zip_digits")->field_path,
+              "$.address.zip");
+}
+
+TEST(ValidationRuleTest, JsonFailFastStopsAtFirstViolation) {
+    EXPECT_EQ(validateJson(jsonOrder("x", 0, {"a"}, "abc"), true).size(), 1);
+}
+
+TEST(ValidationRuleTest, JsonSkipsAbsentAndNullProperties) {
+    nlohmann::json value{{"quantity", 1}, {"items", {"a"}}};
+    EXPECT_TRUE(validateJson(value).empty());
+
+    value["id"] = nullptr;
+    EXPECT_TRUE(validateJson(value).empty());
+}
+
+TEST(ValidationRuleTest, JsonSerializerRejectsInvalidMessage) {
+    auto client = newMockClient();
+    auto ser_config = SerializerConfig::createDefault();
+    ser_config.validation_rules_execution =
+        ValidationRulesExecution::AfterDomainRules;
+
+    Schema schema;
+    schema.setSchemaType(std::make_optional<std::string>("JSON"));
+    schema.setSchema(std::make_optional<std::string>(kJsonSchema));
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+
+    schemaregistry::serdes::json::JsonSerializer serializer(
+        client, std::make_optional(schema), rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Json);
+
+    EXPECT_NO_THROW(
+        serializer.serialize(ctx, jsonOrder("ord-1", 2, {"a", "b"}, "12345")));
+    EXPECT_THROW(
+        serializer.serialize(ctx, jsonOrder("bad", 2, {"a", "b"}, "12345")),
+        ValidationRulesFailedError);
+}
+
+#endif  // SCHEMAREGISTRY_USE_JSON
+
+// --- Protobuf -------------------------------------------------------------
+
+#ifdef SCHEMAREGISTRY_USE_PROTOBUF
+
+namespace {
+
+test::ValidationOrder protoOrder(const std::string &id, int32_t quantity,
+                                 const std::vector<std::string> &items,
+                                 const std::string &zip) {
+    test::ValidationOrder order;
+    order.set_id(id);
+    order.set_quantity(quantity);
+    for (const auto &item : items) {
+        order.add_items(item);
+    }
+    order.mutable_address()->set_zip(zip);
+    return order;
+}
+
+std::vector<ValidationRuleError> validateProto(
+    const google::protobuf::Message &message, bool fail_fast = false) {
+    CelValidator validator;
+    return schemaregistry::serdes::protobuf::utils::validateMessage(
+        validator, message, fail_fast);
+}
+
+}  // namespace
+
+TEST(ValidationRuleTest, ProtobufValidMessageHasNoViolations) {
+    EXPECT_TRUE(
+        validateProto(protoOrder("ord-1234", 2, {"a", "b"}, "12345")).empty());
+}
+
+TEST(ValidationRuleTest, ProtobufCollectsEveryViolation) {
+    auto order = protoOrder("x", -1, {"a", ""}, "abc");
+    auto violations = validateProto(order);
+
+    // Fields are walked in declaration order: id, quantity, items, address.
+    ASSERT_EQ(violations.size(), 6);
+    EXPECT_EQ(violations[0].rule.name, "quantity_matches_items");
+    EXPECT_EQ(violations[0].field_path, "");
+    EXPECT_EQ(violations[1].rule.name, "id_prefix");
+    EXPECT_EQ(violations[1].field_path, "id");
+    EXPECT_EQ(violations[2].rule.name, "id_length");
+    EXPECT_EQ(violations[2].message, "id is too short");
+    EXPECT_EQ(violations[3].rule.name, "positive_quantity");
+    EXPECT_EQ(violations[3].field_path, "quantity");
+    // Repeated fields are validated element by element.
+    EXPECT_EQ(violations[4].rule.name, "item_not_empty");
+    EXPECT_EQ(violations[4].field_path, "items[1]");
+    EXPECT_EQ(violations[5].rule.name, "zip_digits");
+    EXPECT_EQ(violations[5].field_path, "address.zip");
+}
+
+TEST(ValidationRuleTest, ProtobufValidatesNestedMessagesAndMapValues) {
+    auto order = protoOrder("ord-1234", 1, {"a"}, "abc");
+    (*order.mutable_scores())["good"] = 1;
+    (*order.mutable_scores())["bad"] = -1;
+    auto violations = validateProto(order);
+
+    ASSERT_EQ(violations.size(), 2);
+    EXPECT_EQ(violations[0].rule.name, "zip_digits");
+    EXPECT_EQ(violations[0].field_path, "address.zip");
+    EXPECT_EQ(violations[1].rule.name, "score_not_negative");
+    EXPECT_EQ(violations[1].field_path, "scores[\"bad\"]");
+}
+
+TEST(ValidationRuleTest, ProtobufFailFastStopsAtFirstViolation) {
+    EXPECT_EQ(validateProto(protoOrder("x", -1, {"a", ""}, "abc"), true).size(),
+              1);
+}
+
+TEST(ValidationRuleTest, ProtobufSkipsRulesOnUnsetMessageFields) {
+    // address is unset, so the nested zip rule must not be invoked.
+    test::ValidationOrder order;
+    order.set_id("ord-1234");
+    order.set_quantity(1);
+    order.add_items("a");
+    EXPECT_TRUE(validateProto(order).empty());
+}
+
+TEST(ValidationRuleTest, ProtobufSerializerRejectsInvalidMessage) {
+    auto client = newMockClient();
+    auto ser_config = SerializerConfig::createDefault();
+    ser_config.validation_rules_execution =
+        ValidationRulesExecution::AfterDomainRules;
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerValidationExecutor(std::make_shared<CelValidator>());
+
+    schemaregistry::serdes::protobuf::ProtobufSerializer<test::ValidationOrder>
+        serializer(client, std::nullopt, rule_registry, ser_config);
+    auto ctx = valueContext(SerdeFormat::Protobuf);
+
+    EXPECT_NO_THROW(serializer.serialize(
+        ctx, protoOrder("ord-1234", 2, {"a", "b"}, "12345")));
+    EXPECT_THROW(
+        serializer.serialize(ctx, protoOrder("bad", 2, {"a", "b"}, "12345")),
+        ValidationRulesFailedError);
+}
+
+#endif  // SCHEMAREGISTRY_USE_PROTOBUF

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -1299,3 +1299,105 @@ TEST(ValidationRuleTest, JsonSchemaCacheSeparatesSchemasByTheirReferences) {
               flattened_a);
 }
 #endif
+
+#ifdef SCHEMAREGISTRY_USE_JSON
+namespace {
+
+std::shared_ptr<ISchemaRegistryClient> clientWithJsonFieldRule(
+    const std::string &expr, const std::string &schema_json) {
+    auto client = newMockClient();
+    Rule rule;
+    rule.setName("fieldRule");
+    rule.setKind(Kind::Transform);
+    rule.setMode(Mode::Write);
+    rule.setType("CEL_FIELD");
+    rule.setTags(std::vector<std::string>{"PII"});
+    rule.setExpr(expr);
+    RuleSet rule_set;
+    rule_set.setDomainRules(std::vector<Rule>{rule});
+
+    Schema schema;
+    schema.setSchemaType("JSON");
+    schema.setRuleSet(rule_set);
+    schema.setSchema(std::make_optional<std::string>(schema_json));
+    client->registerSchema("test-value", schema, false);
+    return client;
+}
+
+schemaregistry::serdes::json::JsonSerializer jsonSerializerFor(
+    std::shared_ptr<ISchemaRegistryClient> client) {
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(
+        std::make_shared<schemaregistry::rules::cel::CelFieldExecutor>());
+    auto ser_config = SerializerConfig::createDefault();
+    ser_config.auto_register_schemas = false;
+    ser_config.use_schema = SchemaSelector::useLatestVersion();
+    return schemaregistry::serdes::json::JsonSerializer(
+        client, std::nullopt, rule_registry, ser_config);
+}
+
+}  // namespace
+
+// A field transform that fails must reach the caller. transformFields used to wrap the
+// per-field call, the pointer write and the whole walk in catch blocks with empty bodies,
+// so a failing rule left the field with its original value and the serializer reported
+// success - for a field-encryption rule, emitting the plaintext.
+TEST(ValidationRuleTest, JsonFieldTransformFailureIsNotSwallowed) {
+    auto client = clientWithJsonFieldRule("noSuchFunction(value)", R"schema({
+        "type": "object",
+        "properties": {"code": {"type": "string", "confluent:tags": ["PII"]}}
+    })schema");
+    auto ser = jsonSerializerFor(client);
+    auto ctx = valueContext(SerdeFormat::Json);
+
+    nlohmann::json value = {{"code", "secret"}};
+    EXPECT_THROW(ser.serialize(ctx, value), std::exception);
+}
+
+// A transform that succeeds still has to write its result back.
+TEST(ValidationRuleTest, JsonFieldTransformResultIsWrittenBack) {
+    auto client = clientWithJsonFieldRule("value + '-x'", R"schema({
+        "type": "object",
+        "properties": {"code": {"type": "string", "confluent:tags": ["PII"]}}
+    })schema");
+    auto ser = jsonSerializerFor(client);
+    auto ctx = valueContext(SerdeFormat::Json);
+
+    auto bytes = ser.serialize(ctx, nlohmann::json{{"code", "a"}});
+    std::string payload(bytes.begin() + 5, bytes.end());
+    EXPECT_NE(payload.find("a-x"), std::string::npos) << payload;
+}
+
+// getFieldType must not guess String for a schema that declares no usable type: a rule
+// keyed on the field's type would match the wrong fields, and an encryption rule would
+// treat a number or an object as text.
+TEST(ValidationRuleTest, JsonFieldTypeIsDerivedFromTheSchema) {
+    using schemaregistry::serdes::json::utils::schema_navigation::getFieldType;
+    auto typeOf = [](const char *json) {
+        return getFieldType(jsoncons::ojson::parse(json));
+    };
+
+    EXPECT_EQ(typeOf(R"({"type":"string"})"), FieldType::String);
+    EXPECT_EQ(typeOf(R"({"type":"integer"})"), FieldType::Int);
+    EXPECT_EQ(typeOf(R"({"type":"number"})"), FieldType::Double);
+    EXPECT_EQ(typeOf(R"({"type":"boolean"})"), FieldType::Boolean);
+    EXPECT_EQ(typeOf(R"({"type":"array"})"), FieldType::Array);
+    // An object with declared properties is a record; without them, an open map.
+    EXPECT_EQ(typeOf(R"({"type":"object","properties":{"a":{"type":"string"}}})"),
+              FieldType::Record);
+    EXPECT_EQ(typeOf(R"({"type":"object"})"), FieldType::Map);
+    // A nullable field is the type that is not null.
+    EXPECT_EQ(typeOf(R"({"type":["string","null"]})"), FieldType::String);
+    EXPECT_EQ(typeOf(R"({"type":["null","integer"]})"), FieldType::Int);
+    // Genuinely ambiguous, so no single type to act on.
+    EXPECT_EQ(typeOf(R"({"type":["string","integer"]})"), FieldType::Combined);
+    EXPECT_EQ(typeOf(R"({"anyOf":[{"type":"string"},{"type":"integer"}]})"),
+              FieldType::Combined);
+    EXPECT_EQ(typeOf(R"({"type":"string","enum":["a","b"]})"), FieldType::Enum);
+    // No type at all: a record if it declares properties, otherwise nothing to act on -
+    // and never String, which is what it used to return.
+    EXPECT_EQ(typeOf(R"({"properties":{"a":{"type":"string"}}})"), FieldType::Record);
+    EXPECT_EQ(typeOf(R"({"$ref":"#/$defs/Other"})"), FieldType::Null);
+    EXPECT_EQ(typeOf(R"({"type":"unrecognized"})"), FieldType::Null);
+}
+#endif

--- a/test/ValidationRuleTest.cpp
+++ b/test/ValidationRuleTest.cpp
@@ -19,6 +19,7 @@
 #include "schemaregistry/rest/model/RuleSet.h"
 #include "schemaregistry/rest/model/Schema.h"
 #include "schemaregistry/rules/cel/CelExecutor.h"
+#include "schemaregistry/rules/cel/CelFieldExecutor.h"
 #include "schemaregistry/rules/cel/CelValidator.h"
 #include "schemaregistry/serdes/RuleRegistry.h"
 #include "schemaregistry/serdes/SerdeConfig.h"
@@ -39,6 +40,7 @@
 #endif
 
 #ifdef SCHEMAREGISTRY_USE_PROTOBUF
+#include "schemaregistry/serdes/protobuf/ProtobufDeserializer.h"
 #include "schemaregistry/serdes/protobuf/ProtobufSerializer.h"
 #include "schemaregistry/serdes/protobuf/ProtobufUtils.h"
 #include "test/validation.pb.h"
@@ -732,6 +734,59 @@ std::vector<ValidationRuleError> validateProto(
 
 }  // namespace
 
+// A field transform - the walk that drives CSFLE - has to descend into a nested message
+// with that message's own descriptor. Walking it against the containing descriptor applies
+// the parent's fields to the child, which the protobuf reflection API rejects with a fatal
+// error rather than an exception.
+TEST(ValidationRuleTest, ProtobufFieldTransformDescendsIntoNestedMessages) {
+    std::vector<std::string> urls = {"mock://"};
+    auto client_config = std::make_shared<const ClientConfiguration>(urls);
+    auto client = std::make_shared<MockSchemaRegistryClient>(client_config);
+
+    std::unordered_map<std::string, std::string> rule_config;
+    auto ser_conf = SerializerConfig(
+        false, std::make_optional(SchemaSelector::useLatestVersion()), false,
+        false, rule_config);
+
+    test::ValidationOrder obj = protoOrder("ord-1234", 2, {"a", "b"}, "12345");
+
+    Rule rule;
+    rule.setName("test-cel");
+    rule.setKind(Kind::Transform);
+    rule.setMode(Mode::Write);
+    rule.setType("CEL_FIELD");
+    rule.setExpr("typeName == 'STRING' ; value + '-suffix'");
+    RuleSet rule_set;
+    rule_set.setDomainRules(std::vector<Rule>{rule});
+
+    Schema schema;
+    schema.setSchemaType("PROTOBUF");
+    schema.setRuleSet(rule_set);
+    schema.setSchema(
+        protobuf::utils::schemaToString(obj.GetDescriptor()->file()));
+    client->registerSchema("test-value", schema, false);
+
+    auto rule_registry = std::make_shared<RuleRegistry>();
+    rule_registry->registerExecutor(
+        std::make_shared<schemaregistry::rules::cel::CelFieldExecutor>());
+
+    schemaregistry::serdes::protobuf::ProtobufSerializer<test::ValidationOrder>
+        ser(client, std::nullopt, rule_registry, ser_conf);
+    auto ctx = valueContext(SerdeFormat::Protobuf);
+    auto bytes = ser.serialize(ctx, obj);
+
+    // The rule is write-only, so deserializing shows what was written.
+    schemaregistry::serdes::protobuf::ProtobufDeserializer<test::ValidationOrder>
+        deser(client, rule_registry, DeserializerConfig::createDefault());
+    auto result = deser.deserialize(ctx, bytes);
+    const auto *order = dynamic_cast<const test::ValidationOrder *>(result.get());
+    ASSERT_NE(order, nullptr);
+    EXPECT_EQ(order->id(), "ord-1234-suffix");
+    // The nested message's string field is only reached by descending with the
+    // nested descriptor.
+    EXPECT_EQ(order->address().zip(), "12345-suffix");
+}
+
 TEST(ValidationRuleTest, ProtobufMetaIsReadableFromGeneratedDescriptors) {
     // Everything the protobuf walker does depends on this, and so does field
     // encryption, which reads its tags from the same options. If the meta cannot be
@@ -770,9 +825,10 @@ TEST(ValidationRuleTest, ProtobufCollectsEveryViolation) {
     EXPECT_EQ(violations[2].message, "id is too short");
     EXPECT_EQ(violations[3].rule.name, "positive_quantity");
     EXPECT_EQ(violations[3].field_path, "quantity");
-    // Repeated fields are validated element by element.
+    // A repeated field's own rules see the whole list, so the violation is reported
+    // against the field rather than an element.
     EXPECT_EQ(violations[4].rule.name, "item_not_empty");
-    EXPECT_EQ(violations[4].field_path, "items[1]");
+    EXPECT_EQ(violations[4].field_path, "items");
     EXPECT_EQ(violations[5].rule.name, "zip_digits");
     EXPECT_EQ(violations[5].field_path, "address.zip");
 }
@@ -786,8 +842,9 @@ TEST(ValidationRuleTest, ProtobufValidatesNestedMessagesAndMapValues) {
     ASSERT_EQ(violations.size(), 2);
     EXPECT_EQ(violations[0].rule.name, "zip_digits");
     EXPECT_EQ(violations[0].field_path, "address.zip");
+    // As for a repeated field, a map field's own rules see the whole map.
     EXPECT_EQ(violations[1].rule.name, "score_not_negative");
-    EXPECT_EQ(violations[1].field_path, "scores[\"bad\"]");
+    EXPECT_EQ(violations[1].field_path, "scores");
 }
 
 TEST(ValidationRuleTest, ProtobufFailFastStopsAtFirstViolation) {
@@ -911,3 +968,35 @@ TEST(ValidationRuleTest, MessageLevelRulesSeeUnsignedFieldsAndMaps) {
 }
 
 #endif  // SCHEMAREGISTRY_USE_PROTOBUF
+
+// A field-level rule on a repeated or map field is evaluated once, with the whole
+// collection bound to `this` - matching the JVM client - rather than once per element.
+// A rule about the elements is therefore written as a comprehension over them.
+TEST(ValidationRuleTest, ProtobufCollectionRulesSeeTheWholeCollection) {
+    auto order = protoOrder("ord-1234", 2, {"a", "b"}, "12345");
+    (*order.mutable_scores())["ok"] = 1;
+    // size(this) is only answerable if the whole list is bound.
+    EXPECT_TRUE(validateProto(order).empty());
+
+    // One empty element fails the comprehension, and the violation is reported against
+    // the field, once.
+    auto with_empty = protoOrder("ord-1234", 2, {"a", ""}, "12345");
+    auto violations = validateProto(with_empty);
+    ASSERT_EQ(violations.size(), 1);
+    EXPECT_EQ(violations[0].rule.name, "item_not_empty");
+    EXPECT_EQ(violations[0].field_path, "items");
+    EXPECT_TRUE(violations[0].cause.empty());
+
+    // An empty map is bound as an empty map, not skipped and not an error.
+    auto no_scores = protoOrder("ord-1234", 2, {"a", "b"}, "12345");
+    EXPECT_TRUE(validateProto(no_scores).empty());
+
+    // A negative entry fails the comprehension over the map's keys.
+    auto negative = protoOrder("ord-1234", 2, {"a", "b"}, "12345");
+    (*negative.mutable_scores())["bad"] = -1;
+    auto map_violations = validateProto(negative);
+    ASSERT_EQ(map_violations.size(), 1);
+    EXPECT_EQ(map_violations[0].rule.name, "score_not_negative");
+    EXPECT_EQ(map_violations[0].field_path, "scores");
+    EXPECT_TRUE(map_violations[0].cause.empty());
+}

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package test;
+
+import "confluent/meta.proto";
+
+message ValidationAddress {
+  string zip = 1 [(confluent.field_meta) = {
+    rules: [
+      { name: "zip_digits", expr: "this.matches('^[0-9]{5}$') ? '' : 'zip must be 5 digits'" }
+    ]
+  }];
+}
+
+message ValidationOrder {
+  option (confluent.message_meta) = {
+    rules: [
+      {
+        name: "quantity_matches_items",
+        doc: "quantity must match the number of items",
+        expr: "this.quantity == size(this.items)"
+      }
+    ]
+  };
+
+  string id = 1 [(confluent.field_meta) = {
+    rules: [
+      { name: "id_prefix", expr: "this.startsWith('ord-')" },
+      { name: "id_length", expr: "size(this) > 4 ? '' : 'id is too short'" }
+    ]
+  }];
+  int32 quantity = 2 [(confluent.field_meta) = {
+    rules: [
+      { name: "positive_quantity", doc: "quantity must be positive", expr: "this > 0" }
+    ]
+  }];
+  repeated string items = 3 [(confluent.field_meta) = {
+    rules: [
+      { name: "item_not_empty", expr: "size(this) > 0" }
+    ]
+  }];
+  ValidationAddress address = 4;
+  map<string, int32> scores = 5 [(confluent.field_meta) = {
+    rules: [
+      { name: "score_not_negative", expr: "this >= 0" }
+    ]
+  }];
+}

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -76,6 +76,16 @@ message ValidationMessageLevel {
   map<string, int32> scores = 2;
 }
 
+// A map key's type is decided by the key field, not by the value: an unsigned key above
+// int64 max reads as a negative number if it is narrowed on the way into CEL.
+message ValidationUnsignedKeys {
+  map<uint64, int32> by_serial = 1 [(confluent.field_meta) = {
+    rules: [
+      { name: "keys_positive", expr: "this.all(k, k > 0u)" }
+    ]
+  }];
+}
+
 // A well-known type stands for the thing it wraps: a Timestamp is a CEL timestamp and a
 // StringValue is a string. Handing cel-cpp the message lets it downcast them; built as a map
 // of fields they stayed a map, and these rules had no matching overload.

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -53,3 +53,20 @@ message ValidationOrder {
     ]
   }];
 }
+
+// Binding a whole message to `this` goes through a different conversion path than a field
+// value: unsigned fields must stay unsigned, and a map must bind as a CEL map rather than
+// as a list of single-entry maps.
+message ValidationMessageLevel {
+  option (confluent.message_meta) = {
+    rules: [
+      {
+        name: "sees_serial_and_scores",
+        expr: "this.serial > 0 && this.scores['ok'] >= 0"
+      }
+    ]
+  };
+
+  uint64 serial = 1;
+  map<string, int32> scores = 2;
+}

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -45,4 +45,11 @@ message ValidationOrder {
       { name: "score_not_negative", expr: "this >= 0" }
     ]
   }];
+  // Exercises the unsigned conversion: a value above int64 max must still compare as
+  // positive, which it would not if it were narrowed to a signed integer.
+  uint64 serial = 6 [(confluent.field_meta) = {
+    rules: [
+      { name: "serial_positive", expr: "this > 0" }
+    ]
+  }];
 }

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package test;
 
 import "confluent/meta.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 message ValidationAddress {
   string zip = 1 [(confluent.field_meta) = {
@@ -72,4 +74,32 @@ message ValidationMessageLevel {
 
   uint64 serial = 1;
   map<string, int32> scores = 2;
+}
+
+// A well-known type stands for the thing it wraps: a Timestamp is a CEL timestamp and a
+// StringValue is a string. Handing cel-cpp the message lets it downcast them; built as a map
+// of fields they stayed a map, and these rules had no matching overload.
+message ValidationWellKnown {
+  google.protobuf.Timestamp created_at = 1 [(confluent.field_meta) = {
+    rules: [
+      { name: "created_after_epoch", expr: "this > timestamp('1970-01-01T00:00:00Z')" }
+    ]
+  }];
+  google.protobuf.StringValue name = 2 [(confluent.field_meta) = {
+    rules: [
+      { name: "name_not_empty", expr: "size(this) > 0" }
+    ]
+  }];
+}
+
+// Presence shapes, for pinning what has() reports.
+message ValidationPresence {
+  option (confluent.message_meta) = {
+    rules: [
+      { name: "quantity_unset", expr: "has(this.quantity) ? '' : 'quantity is unset'" }
+    ]
+  };
+  int32 quantity = 1;
+  ValidationAddress address = 2;
+  repeated string items = 3;
 }

--- a/test/proto/test/validation.proto
+++ b/test/proto/test/validation.proto
@@ -34,15 +34,18 @@ message ValidationOrder {
       { name: "positive_quantity", doc: "quantity must be positive", expr: "this > 0" }
     ]
   }];
+  // A field-level rule on a repeated or map field is evaluated once, with the whole
+  // collection bound to `this`, so a rule about the elements is written as a
+  // comprehension over them.
   repeated string items = 3 [(confluent.field_meta) = {
     rules: [
-      { name: "item_not_empty", expr: "size(this) > 0" }
+      { name: "item_not_empty", expr: "this.all(i, size(i) > 0)" }
     ]
   }];
   ValidationAddress address = 4;
   map<string, int32> scores = 5 [(confluent.field_meta) = {
     rules: [
-      { name: "score_not_negative", expr: "this >= 0" }
+      { name: "score_not_negative", expr: "this.all(k, this[k] >= 0)" }
     ]
   }];
   // Exercises the unsigned conversion: a value above int64 max must still compare as


### PR DESCRIPTION
Ports the inline validation rules feature ([schema-registry#4291](https://github.com/confluentinc/schema-registry/pull/4291))                                                     
  to the C++ client, following the Python, JavaScript, Go and .NET ports.                                                                                                           
                                                                                                                                                                                    
  Inline validation rules are CHECK constraints declared on the schema itself rather                                                                                                
  than in a rule set — on a record/message/object or on one of its fields — and are                                                                                                 
  evaluated during serialization. Every violation in a message is collected and                                                                                                     
  reported together.                                                                                                                                                                
                                                                                                                                                                                    
  ```json                                                                                                                                                                           
  {                                                                                                                                                                                 
    "type": "record", "name": "Order",                                                                                                                                              
    "confluent:rules": [                                                                                                                                                            
      {"name": "quantity_matches_items", "expr": "this.quantity == size(this.items)"}                                                                                               
    ],                                                                                                                                                                              
    "fields": [                                                                                                                                                                     
      {"name": "id", "type": "string",                                                                                                                                              
       "confluent:rules": [                                                                                                                                                         
         {"name": "id_prefix", "expr": "this.startsWith('ord-')"},                                                                                                                  
         {"name": "id_length", "expr": "size(this) > 4 ? '' : 'id is too short'"}                                                                                                   
       ]}                                                                                                                                                                           
    ]                                                                                                                                                                               
  }                                                                                                                                                                                 
  ```                                                                                                                                                                               
                                                                                                                                                                                    
  A rule returning `false` fails; a rule returning a non-empty string fails with that                                                                                               
  string as the message. Failures are located by dotted path (`addr.zip`, `tags[3]`,                                                                                                
  `scores["foo"]`; `$`-rooted for JSON Schema, matching the JVM client).      

## What's included                                                                                                                                                                
                                                                                                                                                                                    
  **Core model** — `serdes/ValidationRule.{h,cpp}`: `ValidationRulesExecution`,                                                                                                     
  `ValidationRule`, `ValidationRuleError` (message precedence: dynamic message → doc →                                                                                              
  sql → expr, as in the JVM client), `ValidationRulesFailedError` aggregating every                                                                                                 
  violation, and the shared `parseValidationRules` / `evaluateValidationRule` /                                                                                                     
  `raiseValidationViolations` helpers.                                                                                                                                              
                                                                                                                                                                                    
  **Executor** — `rules/cel/CelValidator`, evaluating the rule with `this` bound to the                                                                                             
  value under validation and `now` to the current time. An expression-only `evaluate()`                                                                                             
  was factored out of `CelExecutor::Impl::executeRule` so the validator reuses the                                                                                                  
  existing compiled-expression cache without needing a `RuleContext`. Registered by                                                                                                 
  `registration::registerCelValidator()`, and included in `registerAllCelExecutors()`.                                                                                              
                                                                                                                                                                                    
  **Registry and config** — `RuleRegistry` and `global_registry` gain a validation-executor                                                                                         
  slot. `SerializerConfig` gains:                                                                                                                                                   
                                                                                                                                                                                    
  - `validation_rules_execution` — `Disabled` (default), `BeforeDomainRules`, or                                                                                                    
    `AfterDomainRules`. Disabled by default for parity with the JVM client.                                                                                                         
  - `validation_rules_fail_fast` — stop at the first violation instead of collecting all.                                                                                           
  - `validation_rule_executor` — optional per-serializer override; otherwise the                                                                                                    
    serializer's rule registry is consulted, then the global registry.                                                                                                              
                                                                                                                                                                                    
  **Walkers**, one per format, read-only:                                                                                                                                           
                                                                                                                                                                                    
  - `serdes/avro/AvroValidate.cpp` walks the **raw schema JSON** alongside the datum,                                                                                               
    because avro-cpp drops custom attributes; resolves named-type references and union                                                                                              
    branches. `compileJsonSchema` now strips `confluent:rules` the way it already                                                                                                   
    stripped `confluent:tags` — the Avro parser rejects a schema that still carries them.                                                                                           
  - `serdes/json/JsonValidate.cpp` walks schema and instance as nlohmann JSON, resolving                                                                                            
    local `$ref`.                                                                                                                                                                   
  - `serdes/protobuf/ProtobufValidate.cpp` walks descriptor and message by reflection,                                                                                              
    reading `confluent.message_meta` / `confluent.field_meta`, including repeated fields                                                                                            
    element by element and map values entry by entry.  

All three honor skip-on-null: an absent or null value does not have its rules invoked.                                                                                            
                                                                                                                                                                                    
  **`proto/confluent/meta.proto`** gains `repeated Rule rules = 4;` and `message Rule`.                                                                                             
  No generated code is checked in — protoc runs at build time — so unlike the other                                                                                                 
  clients this needs no codegen version pinning.                                                                                                                                    
                                                                                                                                                                                    
  **Wiring** — the Avro, JSON and Protobuf serializers validate before and/or after                                                                                                 
  domain rules per the configured phase. On the path where no registry schema is found                                                                                              
  (so no domain rules run at all), validation happens once regardless of the configured                                                                                             
  phase, matching the Go client's single-validation-point rule.  